### PR TITLE
Add TypeScript and Python SDKs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,22 @@ jobs:
         with:
           go-version: '1.25'
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install TypeScript SDK dependencies
+        run: cd sdk/typescript && npm ci
+
+      - name: Install Python SDK dependencies
+        run: cd sdk/python && pip install -e ".[dev]"
+
       - name: Run unit tests
         run: make test
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,15 @@ coverage.out
 
 # Air (live reload)
 tmp/
+
+# Node.js
+node_modules/
+
+# Python
+__pycache__/
+*.pyc
+*.egg-info/
+.pytest_cache/
+
+# Build artifacts
+dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ Managed pub/sub event hub with webhooks, DLQ, and real-time subscriptions.
 │   ├── migrations/     # Goose migrations
 │   └── queries/        # sqlc queries
 ├── pkg/client/         # Go SDK
+├── sdk/
+│   ├── typescript/     # TypeScript SDK (npm: notif.sh)
+│   └── python/         # Python SDK (pip: notifsh)
 ├── tests/e2e/          # E2E tests (testcontainers)
 └── web/                # Frontend (TanStack Start)
 ```
@@ -84,6 +87,16 @@ API key format: `nsh_` + 28 alphanumeric chars (regex: `^nsh_[a-zA-Z0-9]{28}$`)
 - `NOTIF_EVENTS`: Events (24h retention, 1GB max)
 - `NOTIF_DLQ`: Dead letter queue (7d retention)
 - Subjects: `events.<topic>`, `dlq.<topic>`
+
+## SDKs
+
+| SDK | Package | Location |
+|-----|---------|----------|
+| Go | `github.com/filipexyz/notif/pkg/client` | `pkg/client/` |
+| TypeScript | `notif.sh` (npm) | `sdk/typescript/` |
+| Python | `notifsh` (pip) | `sdk/python/` |
+
+All SDKs use `NOTIF_API_KEY` env var by default. Core methods: `emit(topic, data)` and `subscribe(...topics)`.
 
 ## Development
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cli run test generate dev dev-down clean seed migrate migrate-down migrate-status
+.PHONY: build build-cli run test generate dev dev-down clean seed migrate migrate-down migrate-status publish-ts publish-py publish-sdks
 
 # Build the server binary
 build:
@@ -94,3 +94,14 @@ watch:
 # Show test key for curl commands
 key:
 	@echo "Test API Key: nsh_test_abcdefghij12345678901234"
+
+# Publish TypeScript SDK to npm
+publish-ts:
+	cd sdk/typescript && npm run build && npm publish
+
+# Publish Python SDK to PyPI
+publish-py:
+	cd sdk/python && python -m build && twine upload dist/*
+
+# Publish all SDKs
+publish-sdks: publish-ts publish-py

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ run: build
 # Run unit tests
 test:
 	go test -v -race ./internal/...
+	cd sdk/typescript && npm test
+	cd sdk/python && pytest
 
 # Run e2e tests (requires Docker)
 test-e2e:

--- a/README.md
+++ b/README.md
@@ -107,6 +107,55 @@ ws.onmessage = (msg) => {
 }
 ```
 
+## SDKs
+
+### TypeScript / Node.js
+
+```bash
+npm install notif.sh
+```
+
+```typescript
+import { Notif } from 'notif.sh'
+
+const n = new Notif()  // Uses NOTIF_API_KEY env var
+
+// Emit
+await n.emit('leads.new', { name: 'John' })
+
+// Subscribe
+for await (const event of n.subscribe('leads.*')) {
+  console.log(event.data)
+}
+
+// Manual ack
+for await (const event of n.subscribe('leads.*', { autoAck: false })) {
+  await event.ack()
+}
+```
+
+### Python
+
+```bash
+pip install notifsh
+```
+
+```python
+from notifsh import Notif
+
+async with Notif() as n:  # Uses NOTIF_API_KEY env var
+    # Emit
+    await n.emit('leads.new', {'name': 'John'})
+
+    # Subscribe
+    async for event in n.subscribe('leads.*'):
+        print(event.data)
+
+    # Manual ack
+    async for event in n.subscribe('leads.*', auto_ack=False):
+        await event.ack()
+```
+
 ## API Reference
 
 ### Authentication
@@ -349,6 +398,9 @@ notif/
 ├── db/
 │   ├── migrations/      # Goose migrations
 │   └── queries/         # SQL queries
+├── sdk/
+│   ├── typescript/      # TypeScript SDK (npm: notif.sh)
+│   └── python/          # Python SDK (pip: notifsh)
 ├── web/                 # Frontend (TanStack Start)
 └── tests/e2e/           # Integration tests
 ```

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,106 @@
+# notifsh
+
+Python SDK for [notif.sh](https://notif.sh) event hub.
+
+## Installation
+
+```bash
+pip install notifsh
+```
+
+## Quick Start
+
+```python
+import asyncio
+from notifsh import Notif
+
+async def main():
+    # Uses NOTIF_API_KEY env var by default
+    async with Notif() as n:
+        # Emit an event
+        await n.emit('leads.new', {'name': 'John', 'email': 'john@example.com'})
+
+        # Subscribe to events (auto-ack by default)
+        async for event in n.subscribe('leads.*'):
+            print(f"Received: {event.topic} - {event.data}")
+
+asyncio.run(main())
+```
+
+## Configuration
+
+```python
+from notifsh import Notif
+
+# Using environment variable (recommended)
+# Set NOTIF_API_KEY=nsh_your_api_key
+client = Notif()
+
+# Or pass API key directly
+client = Notif(api_key='nsh_your_api_key')
+
+# With custom server
+client = Notif(server='http://localhost:8080')
+```
+
+## Emitting Events
+
+```python
+async with Notif() as n:
+    result = await n.emit('orders.created', {
+        'order_id': '12345',
+        'amount': 99.99,
+    })
+    print(f"Event ID: {result.id}")
+```
+
+## Subscribing to Events
+
+```python
+async with Notif() as n:
+    # Subscribe to multiple topics
+    async for event in n.subscribe('orders.*', 'payments.*'):
+        print(f"{event.topic}: {event.data}")
+
+    # Manual acknowledgment
+    async for event in n.subscribe('orders.*', auto_ack=False):
+        try:
+            process(event.data)
+            await event.ack()
+        except Exception:
+            await event.nack('5m')  # Retry in 5 minutes
+
+    # Consumer groups (load-balanced)
+    async for event in n.subscribe('jobs.*', group='worker-pool'):
+        await process_job(event.data)
+
+    # Start from beginning
+    async for event in n.subscribe('orders.*', from_='beginning'):
+        print(event.data)
+```
+
+## Error Handling
+
+```python
+from notifsh import Notif, AuthError, APIError, ConnectionError
+
+try:
+    async with Notif() as n:
+        await n.emit('test', {'data': 'value'})
+except AuthError:
+    print("Invalid API key")
+except APIError as e:
+    print(f"API error ({e.status_code}): {e}")
+except ConnectionError as e:
+    print(f"Connection failed: {e}")
+```
+
+## Requirements
+
+- Python 3.11+
+- httpx
+- websockets
+
+## License
+
+MIT

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "notifsh"
+version = "0.1.0"
+description = "Python SDK for notif.sh event hub"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+authors = [
+    { name = "notif.sh", email = "hello@notif.sh" }
+]
+keywords = ["notif", "notifsh", "pubsub", "events", "webhooks", "websocket", "async"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: AsyncIO",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Internet :: WWW/HTTP",
+    "Typing :: Typed",
+]
+
+dependencies = [
+    "httpx>=0.27.0",
+    "websockets>=12.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-cov>=5.0.0",
+]
+
+[project.urls]
+Homepage = "https://notif.sh"
+Documentation = "https://docs.notif.sh"
+Repository = "https://github.com/filipexyz/notif"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src/notifsh",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/notifsh"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP"]

--- a/sdk/python/src/notifsh/__init__.py
+++ b/sdk/python/src/notifsh/__init__.py
@@ -1,0 +1,19 @@
+"""Python SDK for notif.sh event hub."""
+
+from .client import Notif
+from .errors import APIError, AuthError, ConnectionError, NotifError
+from .events import EventStream
+from .types import EmitResponse, Event
+
+__all__ = [
+    "Notif",
+    "Event",
+    "EventStream",
+    "EmitResponse",
+    "NotifError",
+    "APIError",
+    "AuthError",
+    "ConnectionError",
+]
+
+__version__ = "0.1.0"

--- a/sdk/python/src/notifsh/client.py
+++ b/sdk/python/src/notifsh/client.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from .constants import API_KEY_PREFIX, DEFAULT_SERVER, DEFAULT_TIMEOUT, ENV_VAR_NAME
+from .errors import APIError, AuthError
+from .errors import ConnectionError as NotifConnectionError
+from .events import EventStream
+from .types import EmitResponse
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from .types import Event
+
+
+class Notif:
+    """Async client for notif.sh API."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        server: str = DEFAULT_SERVER,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        """
+        Initialize the Notif client.
+
+        Args:
+            api_key: API key for authentication. If not provided, reads from
+                     NOTIF_API_KEY environment variable.
+            server: Server URL. Defaults to https://api.notif.sh.
+            timeout: Request timeout in seconds. Defaults to 30.
+
+        Raises:
+            AuthError: If no API key is provided or key has invalid format.
+        """
+        resolved_key = api_key or os.environ.get(ENV_VAR_NAME)
+
+        if not resolved_key:
+            raise AuthError(
+                f"API key not provided. Set {ENV_VAR_NAME} environment variable "
+                "or pass api_key argument."
+            )
+
+        if not resolved_key.startswith(API_KEY_PREFIX):
+            raise AuthError(f"API key must start with '{API_KEY_PREFIX}'")
+
+        self._api_key = resolved_key
+        self._server = server
+        self._timeout = timeout
+        self._http_client: httpx.AsyncClient | None = None
+        self._active_streams: set[EventStream] = set()
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(
+                timeout=self._timeout,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+        return self._http_client
+
+    async def emit(self, topic: str, data: dict[str, Any]) -> EmitResponse:
+        """
+        Publish an event to a topic.
+
+        Args:
+            topic: The topic to publish to.
+            data: The event payload (must be JSON-serializable).
+
+        Returns:
+            EmitResponse with the event id, topic, and timestamp.
+
+        Raises:
+            AuthError: If authentication fails.
+            APIError: If the API returns an error.
+            ConnectionError: If there's a network error.
+        """
+        client = await self._get_client()
+
+        try:
+            response = await client.post(
+                f"{self._server}/api/v1/emit",
+                json={"topic": topic, "data": data},
+            )
+        except httpx.RequestError as e:
+            raise NotifConnectionError(str(e), cause=e) from e
+
+        if response.status_code == 401:
+            raise AuthError()
+
+        if response.status_code not in (200, 201):
+            body = response.json() if response.content else {}
+            raise APIError(response.status_code, body.get("error", "emit failed"))
+
+        result = response.json()
+        return EmitResponse(
+            id=result["id"],
+            topic=result["topic"],
+            created_at=datetime.fromisoformat(result["created_at"].replace("Z", "+00:00")),
+        )
+
+    def subscribe(
+        self,
+        *topics: str,
+        auto_ack: bool = True,
+        from_: str | None = None,
+        group: str | None = None,
+    ) -> AsyncIterator[Event]:
+        """
+        Subscribe to events on the given topics.
+
+        Args:
+            *topics: One or more topic patterns to subscribe to (e.g., 'orders.*').
+            auto_ack: If True (default), events are automatically acknowledged
+                      after successful processing. If False, you must call
+                      event.ack() manually.
+            from_: Where to start receiving events. Can be 'latest' (default),
+                   'beginning', or an ISO8601 timestamp.
+            group: Consumer group name for load-balanced consumption.
+
+        Returns:
+            An async iterator that yields Event objects.
+
+        Example:
+            async for event in client.subscribe('orders.*'):
+                print(event.data)
+
+            # With manual ack:
+            async for event in client.subscribe('orders.*', auto_ack=False):
+                await event.ack()
+        """
+        if not topics:
+            raise ValueError("At least one topic is required")
+
+        stream = EventStream(
+            api_key=self._api_key,
+            server=self._server,
+            topics=list(topics),
+            auto_ack=auto_ack,
+            from_=from_ or "latest",
+            group=group,
+        )
+
+        self._active_streams.add(stream)
+        stream._on_close = lambda: self._active_streams.discard(stream)
+
+        return stream
+
+    @property
+    def server_url(self) -> str:
+        """Get the configured server URL."""
+        return self._server
+
+    async def close(self) -> None:
+        """Close the client and clean up resources."""
+        for stream in list(self._active_streams):
+            await stream.close()
+        self._active_streams.clear()
+
+        if self._http_client:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def __aenter__(self) -> Notif:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()

--- a/sdk/python/src/notifsh/constants.py
+++ b/sdk/python/src/notifsh/constants.py
@@ -1,0 +1,4 @@
+DEFAULT_SERVER = "https://api.notif.sh"
+DEFAULT_TIMEOUT = 30.0  # seconds
+ENV_VAR_NAME = "NOTIF_API_KEY"
+API_KEY_PREFIX = "nsh_"

--- a/sdk/python/src/notifsh/errors.py
+++ b/sdk/python/src/notifsh/errors.py
@@ -1,0 +1,27 @@
+class NotifError(Exception):
+    """Base exception for notif SDK."""
+
+    pass
+
+
+class APIError(NotifError):
+    """Error from API (HTTP errors)."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(f"API error ({status_code}): {message}")
+
+
+class AuthError(NotifError):
+    """Authentication error (401)."""
+
+    def __init__(self, message: str = "invalid or missing API key") -> None:
+        super().__init__(f"authentication error: {message}")
+
+
+class ConnectionError(NotifError):
+    """Network/connection failure."""
+
+    def __init__(self, message: str, cause: Exception | None = None) -> None:
+        self.cause = cause
+        super().__init__(f"connection error: {message}")

--- a/sdk/python/src/notifsh/events.py
+++ b/sdk/python/src/notifsh/events.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from typing import Any, Callable
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from .errors import APIError
+from .errors import ConnectionError as NotifConnectionError
+from .types import Event
+
+MAX_RECONNECT_ATTEMPTS = 5
+INITIAL_RECONNECT_DELAY = 1.0
+
+
+class EventStream:
+    """WebSocket event stream that implements async iterator protocol."""
+
+    def __init__(
+        self,
+        api_key: str,
+        server: str,
+        topics: list[str],
+        auto_ack: bool = True,
+        from_: str = "latest",
+        group: str | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._ws_url = server.replace("http://", "ws://").replace("https://", "wss://")
+        self._topics = topics
+        self._auto_ack = auto_ack
+        self._from = from_
+        self._group = group
+
+        self._ws: websockets.WebSocketClientProtocol | None = None
+        self._event_queue: asyncio.Queue[Event] = asyncio.Queue()
+        self._closed = False
+        self._connected = False
+        self._reconnect_attempts = 0
+        self._reader_task: asyncio.Task[None] | None = None
+        self._on_close: Callable[[], None] | None = None
+
+    async def _connect(self) -> None:
+        if self._closed:
+            return
+
+        try:
+            self._ws = await websockets.connect(
+                f"{self._ws_url}/ws",
+                additional_headers={"Authorization": f"Bearer {self._api_key}"},
+            )
+        except Exception as e:
+            raise NotifConnectionError(str(e), cause=e) from e
+
+        # Send subscribe message
+        await self._ws.send(
+            json.dumps(
+                {
+                    "action": "subscribe",
+                    "topics": self._topics,
+                    "options": {
+                        "auto_ack": self._auto_ack,
+                        "from": self._from,
+                        "group": self._group,
+                    },
+                }
+            )
+        )
+
+        # Wait for subscribed confirmation
+        response = json.loads(await self._ws.recv())
+        if response.get("type") == "error":
+            raise APIError(0, response.get("message", "subscription failed"))
+
+        self._connected = True
+        self._reconnect_attempts = 0
+
+        # Start background reader
+        self._reader_task = asyncio.create_task(self._read_messages())
+
+    async def _read_messages(self) -> None:
+        try:
+            async for message in self._ws:  # type: ignore[union-attr]
+                data = json.loads(message)
+
+                if data.get("type") == "event":
+                    event = self._create_event(data)
+                    await self._event_queue.put(event)
+
+                elif data.get("type") == "error":
+                    # Log error but don't stop iteration
+                    pass
+
+        except ConnectionClosed:
+            self._connected = False
+            if not self._closed:
+                await self._attempt_reconnect()
+        except Exception:
+            self._connected = False
+
+    def _create_event(self, data: dict[str, Any]) -> Event:
+        event_id = data["id"]
+        auto_ack = self._auto_ack
+
+        async def ack() -> None:
+            if auto_ack:
+                return  # Server already acked
+            await self._send_ack(event_id)
+
+        async def nack(retry_in: str | None = None) -> None:
+            if auto_ack:
+                return  # Server already acked, can't nack
+            await self._send_nack(event_id, retry_in)
+
+        return Event(
+            id=event_id,
+            topic=data["topic"],
+            data=data.get("data", {}),
+            timestamp=datetime.fromisoformat(data["timestamp"].replace("Z", "+00:00")),
+            attempt=data.get("attempt", 1),
+            max_attempts=data.get("max_attempts", 5),
+            _ack_fn=ack,
+            _nack_fn=nack,
+        )
+
+    async def _send_ack(self, event_id: str) -> None:
+        if self._ws and self._connected:
+            await self._ws.send(json.dumps({"action": "ack", "id": event_id}))
+
+    async def _send_nack(self, event_id: str, retry_in: str | None = None) -> None:
+        if self._ws and self._connected:
+            await self._ws.send(
+                json.dumps(
+                    {
+                        "action": "nack",
+                        "id": event_id,
+                        "retry_in": retry_in or "5m",
+                    }
+                )
+            )
+
+    async def _attempt_reconnect(self) -> None:
+        if self._reconnect_attempts >= MAX_RECONNECT_ATTEMPTS:
+            self._closed = True
+            return
+
+        delay = INITIAL_RECONNECT_DELAY * (2**self._reconnect_attempts)
+        self._reconnect_attempts += 1
+
+        await asyncio.sleep(delay)
+
+        if not self._closed:
+            try:
+                await self._connect()
+            except Exception:
+                await self._attempt_reconnect()
+
+    def __aiter__(self) -> EventStream:
+        return self
+
+    async def __anext__(self) -> Event:
+        # Connect on first iteration
+        if not self._connected and not self._closed:
+            await self._connect()
+
+        while True:
+            if self._closed and self._event_queue.empty():
+                raise StopAsyncIteration
+
+            try:
+                event = await asyncio.wait_for(self._event_queue.get(), timeout=1.0)
+                return event
+
+            except asyncio.TimeoutError:
+                if self._closed:
+                    raise StopAsyncIteration
+                continue
+
+    async def close(self) -> None:
+        """Close the event stream."""
+        if self._closed:
+            return
+
+        self._closed = True
+
+        if self._reader_task:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._ws:
+            await self._ws.close()
+
+        self._connected = False
+
+        if self._on_close:
+            self._on_close()
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if the stream is connected."""
+        return self._connected

--- a/sdk/python/src/notifsh/types.py
+++ b/sdk/python/src/notifsh/types.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Coroutine
+
+
+@dataclass
+class EmitResponse:
+    """Response from emitting an event."""
+
+    id: str
+    topic: str
+    created_at: datetime
+
+
+@dataclass
+class Event:
+    """Event received from a subscription."""
+
+    id: str
+    topic: str
+    data: dict[str, Any]
+    timestamp: datetime
+    attempt: int
+    max_attempts: int
+    _ack_fn: Callable[[], Coroutine[Any, Any, None]] = field(repr=False)
+    _nack_fn: Callable[[str | None], Coroutine[Any, Any, None]] = field(repr=False)
+
+    async def ack(self) -> None:
+        """Acknowledge this event (only works when auto_ack=False)."""
+        await self._ack_fn()
+
+    async def nack(self, retry_in: str | None = None) -> None:
+        """Negative acknowledge this event, requesting redelivery (only works when auto_ack=False)."""
+        await self._nack_fn(retry_in)

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_env():
+    """Clear NOTIF_API_KEY env var before each test."""
+    env_key = "NOTIF_API_KEY"
+    original = os.environ.get(env_key)
+    os.environ.pop(env_key, None)
+    yield
+    if original:
+        os.environ[env_key] = original
+    else:
+        os.environ.pop(env_key, None)

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1,0 +1,151 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from notifsh import APIError, AuthError, Notif
+from notifsh.errors import ConnectionError as NotifConnectionError
+
+
+class TestNotifConstructor:
+    """Test Notif client constructor."""
+
+    def test_raises_auth_error_when_no_api_key(self):
+        with pytest.raises(AuthError, match="API key not provided"):
+            Notif()
+
+    def test_raises_auth_error_when_invalid_prefix(self):
+        with pytest.raises(AuthError, match="must start with 'nsh_'"):
+            Notif(api_key="invalid_key")
+
+    def test_accepts_valid_api_key(self):
+        client = Notif(api_key="nsh_testkey12345678901234567890")
+        assert client is not None
+
+    def test_reads_api_key_from_env_var(self):
+        os.environ["NOTIF_API_KEY"] = "nsh_envkey12345678901234567890"
+        client = Notif()
+        assert client is not None
+
+    def test_prefers_argument_over_env_var(self):
+        os.environ["NOTIF_API_KEY"] = "nsh_envkey12345678901234567890"
+        client = Notif(api_key="nsh_argkey12345678901234567890")
+        assert client.server_url == "https://api.notif.sh"
+
+    def test_uses_default_server(self):
+        client = Notif(api_key="nsh_testkey12345678901234567890")
+        assert client.server_url == "https://api.notif.sh"
+
+    def test_uses_custom_server(self):
+        client = Notif(
+            api_key="nsh_testkey12345678901234567890",
+            server="http://localhost:8080",
+        )
+        assert client.server_url == "http://localhost:8080"
+
+
+class TestNotifEmit:
+    """Test Notif.emit() method."""
+
+    @pytest.fixture
+    def client(self):
+        return Notif(api_key="nsh_testkey12345678901234567890")
+
+    @pytest.mark.asyncio
+    async def test_emit_success(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b'{"id": "evt_123", "topic": "test.topic", "created_at": "2025-01-01T00:00:00Z"}'
+        mock_response.json.return_value = {
+            "id": "evt_123",
+            "topic": "test.topic",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+
+        with patch.object(client, "_get_client") as mock_get_client:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_response)
+            mock_get_client.return_value = mock_http
+
+            result = await client.emit("test.topic", {"foo": "bar"})
+
+            assert result.id == "evt_123"
+            assert result.topic == "test.topic"
+            mock_http.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_emit_auth_error(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        with patch.object(client, "_get_client") as mock_get_client:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_response)
+            mock_get_client.return_value = mock_http
+
+            with pytest.raises(AuthError):
+                await client.emit("test", {})
+
+    @pytest.mark.asyncio
+    async def test_emit_api_error(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.content = b'{"error": "topic is required"}'
+        mock_response.json.return_value = {"error": "topic is required"}
+
+        with patch.object(client, "_get_client") as mock_get_client:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(return_value=mock_response)
+            mock_get_client.return_value = mock_http
+
+            with pytest.raises(APIError) as exc_info:
+                await client.emit("", {})
+
+            assert exc_info.value.status_code == 400
+            assert "topic is required" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_emit_connection_error(self, client):
+        import httpx
+
+        with patch.object(client, "_get_client") as mock_get_client:
+            mock_http = AsyncMock()
+            mock_http.post = AsyncMock(side_effect=httpx.RequestError("Network error"))
+            mock_get_client.return_value = mock_http
+
+            with pytest.raises(NotifConnectionError):
+                await client.emit("test", {})
+
+
+class TestNotifSubscribe:
+    """Test Notif.subscribe() method."""
+
+    def test_raises_error_when_no_topics(self):
+        client = Notif(api_key="nsh_testkey12345678901234567890")
+        with pytest.raises(ValueError, match="At least one topic is required"):
+            client.subscribe()
+
+    def test_accepts_single_topic(self):
+        client = Notif(api_key="nsh_testkey12345678901234567890")
+        stream = client.subscribe("test.*")
+        assert stream is not None
+
+    def test_accepts_multiple_topics(self):
+        client = Notif(api_key="nsh_testkey12345678901234567890")
+        stream = client.subscribe("orders.*", "leads.*")
+        assert stream is not None
+
+    def test_accepts_options(self):
+        client = Notif(api_key="nsh_testkey12345678901234567890")
+        stream = client.subscribe("test.*", auto_ack=False, from_="beginning")
+        assert stream is not None
+
+
+class TestNotifContextManager:
+    """Test Notif as async context manager."""
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self):
+        async with Notif(api_key="nsh_testkey12345678901234567890") as client:
+            assert client is not None
+            assert client.server_url == "https://api.notif.sh"

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,123 @@
+# notif.sh
+
+TypeScript SDK for [notif.sh](https://notif.sh) event hub.
+
+## Installation
+
+```bash
+npm install notif.sh
+```
+
+## Quick Start
+
+```typescript
+import { Notif } from 'notif.sh'
+
+// Uses NOTIF_API_KEY env var by default
+const n = new Notif()
+
+// Emit an event
+await n.emit('leads.new', { name: 'John', email: 'john@example.com' })
+
+// Subscribe to events (auto-ack by default)
+for await (const event of n.subscribe('leads.*')) {
+  console.log(`Received: ${event.topic} - ${JSON.stringify(event.data)}`)
+}
+
+n.close()
+```
+
+## Configuration
+
+```typescript
+import { Notif } from 'notif.sh'
+
+// Using environment variable (recommended)
+// Set NOTIF_API_KEY=nsh_your_api_key
+const client = new Notif()
+
+// Or pass API key directly
+const client = new Notif({ apiKey: 'nsh_your_api_key' })
+
+// With custom server
+const client = new Notif({ server: 'http://localhost:8080' })
+
+// With custom timeout (ms)
+const client = new Notif({ timeout: 60000 })
+```
+
+## Emitting Events
+
+```typescript
+const n = new Notif()
+
+const result = await n.emit('orders.created', {
+  orderId: '12345',
+  amount: 99.99,
+})
+
+console.log(`Event ID: ${result.id}`)
+
+n.close()
+```
+
+## Subscribing to Events
+
+```typescript
+const n = new Notif()
+
+// Subscribe to multiple topics
+for await (const event of n.subscribe('orders.*', 'payments.*')) {
+  console.log(`${event.topic}: ${JSON.stringify(event.data)}`)
+}
+
+// Manual acknowledgment
+for await (const event of n.subscribe('orders.*', { autoAck: false })) {
+  try {
+    await process(event.data)
+    await event.ack()
+  } catch (err) {
+    await event.nack('5m') // Retry in 5 minutes
+  }
+}
+
+// Consumer groups (load-balanced)
+for await (const event of n.subscribe('jobs.*', { group: 'worker-pool' })) {
+  await processJob(event.data)
+}
+
+// Start from beginning
+for await (const event of n.subscribe('orders.*', { from: 'beginning' })) {
+  console.log(event.data)
+}
+
+n.close()
+```
+
+## Error Handling
+
+```typescript
+import { Notif, AuthError, APIError, ConnectionError } from 'notif.sh'
+
+try {
+  const n = new Notif()
+  await n.emit('test', { data: 'value' })
+  n.close()
+} catch (err) {
+  if (err instanceof AuthError) {
+    console.log('Invalid API key')
+  } else if (err instanceof APIError) {
+    console.log(`API error (${err.statusCode}): ${err.message}`)
+  } else if (err instanceof ConnectionError) {
+    console.log(`Connection failed: ${err.message}`)
+  }
+}
+```
+
+## Requirements
+
+- Node.js 18+
+
+## License
+
+MIT

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,0 +1,1613 @@
+{
+  "name": "notifsh",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "notifsh",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.5.13",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
+      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
+      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
+      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
+      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
+      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
+      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
+      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
+      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
+      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
+      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
+      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
+      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
+      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
+      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
+      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
+      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
+      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
+      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
+      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
+      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
+      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.54.0",
+        "@rollup/rollup-android-arm64": "4.54.0",
+        "@rollup/rollup-darwin-arm64": "4.54.0",
+        "@rollup/rollup-darwin-x64": "4.54.0",
+        "@rollup/rollup-freebsd-arm64": "4.54.0",
+        "@rollup/rollup-freebsd-x64": "4.54.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
+        "@rollup/rollup-linux-arm64-musl": "4.54.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-musl": "4.54.0",
+        "@rollup/rollup-openharmony-arm64": "4.54.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
+        "@rollup/rollup-win32-x64-gnu": "4.54.0",
+        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
+      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "notif.sh",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for notif.sh event hub",
+  "type": "module",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "npm run build:esm && npm run build:cjs && npm run build:types",
+    "build:esm": "tsc -p tsconfig.build.json --outDir dist/esm",
+    "build:cjs": "tsc -p tsconfig.build.json --outDir dist/cjs --module commonjs --moduleResolution node",
+    "build:types": "tsc -p tsconfig.build.json --outDir dist/types --declaration --emitDeclarationOnly",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.13",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "keywords": [
+    "notif",
+    "notifsh",
+    "pubsub",
+    "events",
+    "webhooks",
+    "websocket"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/filipexyz/notif.git",
+    "directory": "sdk/typescript"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,130 @@
+import { DEFAULT_SERVER, DEFAULT_TIMEOUT, ENV_VAR_NAME, API_KEY_PREFIX } from './constants.js'
+import { AuthError, APIError, ConnectionError, NotifError } from './errors.js'
+import { NotifOptions, SubscribeOptions, EmitResponse } from './types.js'
+import { EventStream } from './events.js'
+
+export class Notif {
+  private readonly apiKey: string
+  private readonly server: string
+  private readonly timeout: number
+  private activeStreams: Set<EventStream> = new Set()
+
+  constructor(options: NotifOptions = {}) {
+    const apiKey = options.apiKey ?? process.env[ENV_VAR_NAME]
+
+    if (!apiKey) {
+      throw new AuthError(`API key not provided. Set ${ENV_VAR_NAME} environment variable or pass apiKey option.`)
+    }
+
+    if (!apiKey.startsWith(API_KEY_PREFIX)) {
+      throw new AuthError(`API key must start with '${API_KEY_PREFIX}'`)
+    }
+
+    this.apiKey = apiKey
+    this.server = options.server ?? DEFAULT_SERVER
+    this.timeout = options.timeout ?? DEFAULT_TIMEOUT
+  }
+
+  async emit(topic: string, data: Record<string, unknown>): Promise<EmitResponse> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout)
+
+    try {
+      const response = await fetch(`${this.server}/api/v1/emit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({ topic, data }),
+        signal: controller.signal,
+      })
+
+      clearTimeout(timeoutId)
+
+      if (response.status === 401) {
+        throw new AuthError()
+      }
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({ error: 'emit failed' })) as { error?: string }
+        throw new APIError(response.status, body.error ?? 'emit failed')
+      }
+
+      return await response.json() as EmitResponse
+    } catch (error) {
+      clearTimeout(timeoutId)
+
+      if (error instanceof NotifError) throw error
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new ConnectionError('request timeout')
+      }
+
+      throw new ConnectionError('network error', error as Error)
+    }
+  }
+
+  /**
+   * Subscribe to events on the given topics.
+   *
+   * @param topics - One or more topic patterns (e.g., 'orders.*')
+   * @param options - Subscription options
+   * @returns AsyncIterable that yields events
+   *
+   * @example
+   * // Single topic
+   * for await (const event of client.subscribe('orders.*')) { ... }
+   *
+   * // Multiple topics
+   * for await (const event of client.subscribe('orders.*', 'leads.*')) { ... }
+   *
+   * // With options
+   * for await (const event of client.subscribe('orders.*', { autoAck: false })) {
+   *   await event.ack()
+   * }
+   */
+  subscribe(...args: [...string[], SubscribeOptions] | string[] | [string[]] | [string[], SubscribeOptions]): EventStream {
+    // Parse arguments: variadic topics with optional options object at the end
+    let topics: string[]
+    let options: SubscribeOptions = {}
+
+    const lastArg = args[args.length - 1]
+    if (typeof lastArg === 'object' && lastArg !== null && !Array.isArray(lastArg)) {
+      options = lastArg as SubscribeOptions
+      topics = args.slice(0, -1) as string[]
+    } else {
+      topics = args as string[]
+    }
+
+    // Handle array as first argument: subscribe(['a', 'b']) or subscribe(['a', 'b'], options)
+    if (topics.length >= 1 && Array.isArray(topics[0])) {
+      topics = topics[0] as unknown as string[]
+    }
+
+    if (topics.length === 0) {
+      throw new Error('At least one topic is required')
+    }
+
+    const stream = new EventStream(this.apiKey, this.server, topics, options)
+    this.activeStreams.add(stream)
+
+    // Remove from active streams when closed
+    stream.onClose(() => {
+      this.activeStreams.delete(stream)
+    })
+
+    return stream
+  }
+
+  close(): void {
+    for (const stream of this.activeStreams) {
+      stream.close()
+    }
+    this.activeStreams.clear()
+  }
+
+  get serverUrl(): string {
+    return this.server
+  }
+}

--- a/sdk/typescript/src/constants.ts
+++ b/sdk/typescript/src/constants.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_SERVER = 'https://api.notif.sh'
+export const DEFAULT_TIMEOUT = 30000 // 30 seconds in milliseconds
+export const ENV_VAR_NAME = 'NOTIF_API_KEY'
+export const API_KEY_PREFIX = 'nsh_'

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,0 +1,33 @@
+export class NotifError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotifError'
+  }
+}
+
+export class APIError extends NotifError {
+  constructor(
+    public readonly statusCode: number,
+    message: string
+  ) {
+    super(`API error (${statusCode}): ${message}`)
+    this.name = 'APIError'
+  }
+}
+
+export class AuthError extends NotifError {
+  constructor(message: string = 'invalid or missing API key') {
+    super(`authentication error: ${message}`)
+    this.name = 'AuthError'
+  }
+}
+
+export class ConnectionError extends NotifError {
+  constructor(
+    message: string,
+    public readonly cause?: Error
+  ) {
+    super(`connection error: ${message}`)
+    this.name = 'ConnectionError'
+  }
+}

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -1,0 +1,247 @@
+import WebSocket from 'ws'
+import { SubscribeOptions, ResolvedSubscribeOptions, Event, ServerMessage, EventMessage } from './types.js'
+import { ConnectionError, APIError } from './errors.js'
+
+const MAX_RECONNECT_ATTEMPTS = 5
+const INITIAL_RECONNECT_DELAY = 1000
+
+export class EventStream implements AsyncIterable<Event> {
+  private ws: WebSocket | null = null
+  private readonly wsUrl: string
+  private readonly topics: string[]
+  private readonly options: ResolvedSubscribeOptions
+  private readonly apiKey: string
+
+  private eventQueue: Event[] = []
+  private eventResolvers: Array<(value: IteratorResult<Event>) => void> = []
+  private errorResolvers: Array<(error: Error) => void> = []
+
+  private closed = false
+  private connected = false
+  private connectStarted = false
+  private reconnectAttempts = 0
+  private closeCallbacks: Array<() => void> = []
+
+  constructor(
+    apiKey: string,
+    server: string,
+    topics: string[],
+    options: SubscribeOptions = {}
+  ) {
+    this.apiKey = apiKey
+    this.wsUrl = server.replace('http://', 'ws://').replace('https://', 'wss://')
+    this.topics = topics
+    this.options = {
+      autoAck: options.autoAck ?? true,
+      from: options.from ?? 'latest',
+      group: options.group,
+    }
+    // Connection deferred to first iteration
+  }
+
+  private connect(): void {
+    if (this.closed) return
+
+    try {
+      this.ws = new WebSocket(`${this.wsUrl}/ws`, {
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+        },
+      })
+
+      this.ws.on('open', () => {
+        this.connected = true
+        this.reconnectAttempts = 0
+        this.sendSubscribe()
+      })
+
+      this.ws.on('message', (data: WebSocket.Data) => {
+        try {
+          const msg = JSON.parse(data.toString()) as ServerMessage
+          this.handleMessage(msg)
+        } catch {
+          // Ignore parse errors
+        }
+      })
+
+      this.ws.on('error', () => {
+        this.rejectPending(new ConnectionError('WebSocket error'))
+      })
+
+      this.ws.on('close', () => {
+        this.connected = false
+        if (!this.closed) {
+          this.attemptReconnect()
+        }
+      })
+    } catch (error) {
+      this.rejectPending(new ConnectionError('Failed to connect', error as Error))
+    }
+  }
+
+  private sendSubscribe(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
+
+    this.ws.send(JSON.stringify({
+      action: 'subscribe',
+      topics: this.topics,
+      options: {
+        auto_ack: this.options.autoAck,
+        from: this.options.from,
+        group: this.options.group,
+      },
+    }))
+  }
+
+  private handleMessage(msg: ServerMessage): void {
+    switch (msg.type) {
+      case 'event':
+        this.handleEvent(msg)
+        break
+      case 'error':
+        this.rejectPending(new APIError(0, msg.message))
+        break
+      case 'subscribed':
+      case 'pong':
+        // Ignore these
+        break
+    }
+  }
+
+  private handleEvent(msg: EventMessage): void {
+    const event = this.createEvent(msg)
+
+    // If there's a waiting resolver, resolve immediately
+    const resolver = this.eventResolvers.shift()
+    if (resolver) {
+      resolver({ value: event, done: false })
+    } else {
+      // Otherwise queue the event
+      this.eventQueue.push(event)
+    }
+  }
+
+  private createEvent(msg: EventMessage): Event {
+    const autoAck = this.options.autoAck
+    return {
+      id: msg.id,
+      topic: msg.topic,
+      data: msg.data,
+      timestamp: msg.timestamp,
+      attempt: msg.attempt,
+      maxAttempts: msg.max_attempts,
+      ack: async () => {
+        if (autoAck) return // Server already acked
+        this.sendAck(msg.id)
+      },
+      nack: async (retryIn?: string) => {
+        if (autoAck) return // Server already acked, can't nack
+        this.sendNack(msg.id, retryIn)
+      },
+    }
+  }
+
+  private sendAck(eventId: string): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
+    this.ws.send(JSON.stringify({ action: 'ack', id: eventId }))
+  }
+
+  private sendNack(eventId: string, retryIn?: string): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
+    this.ws.send(JSON.stringify({
+      action: 'nack',
+      id: eventId,
+      retry_in: retryIn ?? '5m',
+    }))
+  }
+
+  private attemptReconnect(): void {
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      this.rejectPending(new ConnectionError('max reconnection attempts reached'))
+      this.close()
+      return
+    }
+
+    const delay = INITIAL_RECONNECT_DELAY * Math.pow(2, this.reconnectAttempts)
+    this.reconnectAttempts++
+
+    setTimeout(() => {
+      if (!this.closed) {
+        this.connect()
+      }
+    }, delay)
+  }
+
+  private rejectPending(error: Error): void {
+    const rejector = this.errorResolvers.shift()
+    if (rejector) {
+      rejector(error)
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<Event> {
+    // Connect on first iteration (deferred connection)
+    if (!this.connectStarted) {
+      this.connectStarted = true
+      this.connect()
+    }
+
+    while (!this.closed) {
+      // If there are queued events, yield them
+      if (this.eventQueue.length > 0) {
+        const event = this.eventQueue.shift()!
+        yield event
+        continue
+      }
+
+      // Wait for next event or error
+      try {
+        const result = await new Promise<IteratorResult<Event>>((resolve, reject) => {
+          this.eventResolvers.push(resolve)
+          this.errorResolvers.push(reject)
+        })
+
+        if (result.done) {
+          return
+        }
+
+        yield result.value
+      } catch (error) {
+        // On error, throw to let the caller handle it
+        throw error
+      }
+    }
+  }
+
+  onClose(callback: () => void): void {
+    this.closeCallbacks.push(callback)
+  }
+
+  close(): void {
+    if (this.closed) return
+
+    this.closed = true
+
+    // Resolve any pending promises with done
+    for (const resolver of this.eventResolvers) {
+      resolver({ value: undefined as unknown as Event, done: true })
+    }
+    this.eventResolvers = []
+    this.errorResolvers = []
+
+    // Close WebSocket
+    if (this.ws) {
+      this.ws.close()
+      this.ws = null
+    }
+
+    // Call close callbacks
+    for (const callback of this.closeCallbacks) {
+      callback()
+    }
+  }
+
+  get isConnected(): boolean {
+    return this.connected
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,9 @@
+export { Notif } from './client.js'
+export { EventStream } from './events.js'
+export { NotifError, APIError, AuthError, ConnectionError } from './errors.js'
+export type {
+  NotifOptions,
+  SubscribeOptions,
+  EmitResponse,
+  Event,
+} from './types.js'

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,0 +1,91 @@
+export interface NotifOptions {
+  apiKey?: string
+  server?: string
+  timeout?: number
+}
+
+export interface SubscribeOptions {
+  autoAck?: boolean
+  from?: 'latest' | 'beginning' | string
+  group?: string | undefined
+}
+
+export interface ResolvedSubscribeOptions {
+  autoAck: boolean
+  from: string
+  group: string | undefined
+}
+
+export interface EmitResponse {
+  id: string
+  topic: string
+  created_at: string
+}
+
+export interface Event {
+  id: string
+  topic: string
+  data: Record<string, unknown>
+  timestamp: string
+  attempt: number
+  maxAttempts: number
+  ack: () => Promise<void>
+  nack: (retryIn?: string) => Promise<void>
+}
+
+// Internal types for WebSocket protocol
+
+export interface SubscribeMessage {
+  action: 'subscribe'
+  topics: string[]
+  options: {
+    auto_ack: boolean
+    from: string
+    group?: string
+  }
+}
+
+export interface AckMessage {
+  action: 'ack'
+  id: string
+}
+
+export interface NackMessage {
+  action: 'nack'
+  id: string
+  retry_in: string
+}
+
+export interface PingMessage {
+  action: 'ping'
+}
+
+export type ClientMessage = SubscribeMessage | AckMessage | NackMessage | PingMessage
+
+export interface SubscribedMessage {
+  type: 'subscribed'
+  topics: string[]
+  consumer_id: string
+}
+
+export interface EventMessage {
+  type: 'event'
+  id: string
+  topic: string
+  data: Record<string, unknown>
+  timestamp: string
+  attempt: number
+  max_attempts: number
+}
+
+export interface ErrorMessage {
+  type: 'error'
+  code: string
+  message: string
+}
+
+export interface PongMessage {
+  type: 'pong'
+}
+
+export type ServerMessage = SubscribedMessage | EventMessage | ErrorMessage | PongMessage

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Notif, AuthError, APIError, ConnectionError } from '../src/index.js'
+
+describe('Notif', () => {
+  const validApiKey = 'nsh_testkey12345678901234567890'
+
+  beforeEach(() => {
+    vi.stubEnv('NOTIF_API_KEY', '')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  describe('constructor', () => {
+    it('throws AuthError when no API key provided', () => {
+      expect(() => new Notif()).toThrow(AuthError)
+      expect(() => new Notif()).toThrow(/API key not provided/)
+    })
+
+    it('throws AuthError when API key has invalid prefix', () => {
+      expect(() => new Notif({ apiKey: 'invalid_key' })).toThrow(AuthError)
+      expect(() => new Notif({ apiKey: 'invalid_key' })).toThrow(/must start with 'nsh_'/)
+    })
+
+    it('accepts valid API key from options', () => {
+      const client = new Notif({ apiKey: validApiKey })
+      expect(client).toBeInstanceOf(Notif)
+    })
+
+    it('reads API key from environment variable', () => {
+      vi.stubEnv('NOTIF_API_KEY', validApiKey)
+      const client = new Notif()
+      expect(client).toBeInstanceOf(Notif)
+    })
+
+    it('prefers options API key over environment variable', () => {
+      vi.stubEnv('NOTIF_API_KEY', 'nsh_envkey12345678901234567890')
+      const client = new Notif({ apiKey: validApiKey })
+      expect(client.serverUrl).toBe('https://api.notif.sh')
+    })
+
+    it('uses default server URL', () => {
+      const client = new Notif({ apiKey: validApiKey })
+      expect(client.serverUrl).toBe('https://api.notif.sh')
+    })
+
+    it('uses custom server URL from options', () => {
+      const client = new Notif({
+        apiKey: validApiKey,
+        server: 'http://localhost:8080',
+      })
+      expect(client.serverUrl).toBe('http://localhost:8080')
+    })
+  })
+
+  describe('emit', () => {
+    it('sends POST request with correct headers and body', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          id: 'evt_123',
+          topic: 'test.topic',
+          created_at: '2025-01-01T00:00:00Z',
+        }),
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const client = new Notif({ apiKey: validApiKey })
+      const result = await client.emit('test.topic', { foo: 'bar' })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.notif.sh/api/v1/emit',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${validApiKey}`,
+          },
+          body: JSON.stringify({ topic: 'test.topic', data: { foo: 'bar' } }),
+        })
+      )
+      expect(result.id).toBe('evt_123')
+      expect(result.topic).toBe('test.topic')
+    })
+
+    it('throws AuthError on 401 response', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const client = new Notif({ apiKey: validApiKey })
+      await expect(client.emit('test', {})).rejects.toThrow(AuthError)
+    })
+
+    it('throws APIError on 400 response', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: 'topic is required' }),
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const client = new Notif({ apiKey: validApiKey })
+      await expect(client.emit('', {})).rejects.toThrow(APIError)
+      await expect(client.emit('', {})).rejects.toThrow('topic is required')
+    })
+
+    it('throws APIError on 500 response', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'internal error' }),
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const client = new Notif({ apiKey: validApiKey })
+      await expect(client.emit('test', {})).rejects.toThrow(APIError)
+    })
+
+    it('throws ConnectionError on network failure', async () => {
+      const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
+      vi.stubGlobal('fetch', mockFetch)
+
+      const client = new Notif({ apiKey: validApiKey })
+      await expect(client.emit('test', {})).rejects.toThrow(ConnectionError)
+    })
+
+    it('throws ConnectionError on timeout', async () => {
+      const mockFetch = vi.fn().mockImplementation(() => {
+        const error = new Error('Aborted')
+        error.name = 'AbortError'
+        return Promise.reject(error)
+      })
+      vi.stubGlobal('fetch', mockFetch)
+
+      const client = new Notif({ apiKey: validApiKey, timeout: 100 })
+      await expect(client.emit('test', {})).rejects.toThrow(ConnectionError)
+      await expect(client.emit('test', {})).rejects.toThrow('request timeout')
+    })
+  })
+
+  describe('subscribe', () => {
+    it('throws error when no topics provided', () => {
+      const client = new Notif({ apiKey: validApiKey })
+      expect(() => client.subscribe([])).toThrow('At least one topic is required')
+    })
+
+    it('accepts single topic as string', () => {
+      const client = new Notif({ apiKey: validApiKey })
+      const stream = client.subscribe('test.*')
+      expect(stream).toBeDefined()
+      stream.close()
+      client.close()
+    })
+
+    it('accepts multiple topics', () => {
+      const client = new Notif({ apiKey: validApiKey })
+      const stream = client.subscribe('orders.*', 'leads.*')
+      expect(stream).toBeDefined()
+      stream.close()
+      client.close()
+    })
+
+    it('accepts topics array', () => {
+      const client = new Notif({ apiKey: validApiKey })
+      const stream = client.subscribe(['orders.*', 'leads.*'])
+      expect(stream).toBeDefined()
+      stream.close()
+      client.close()
+    })
+
+    it('accepts options as last argument', () => {
+      const client = new Notif({ apiKey: validApiKey })
+      const stream = client.subscribe('test.*', { autoAck: false, from: 'beginning' })
+      expect(stream).toBeDefined()
+      stream.close()
+      client.close()
+    })
+  })
+
+  describe('close', () => {
+    it('closes all active streams', () => {
+      const client = new Notif({ apiKey: validApiKey })
+      const stream1 = client.subscribe('topic1')
+      const stream2 = client.subscribe('topic2')
+
+      client.close()
+
+      expect(stream1.isConnected).toBe(false)
+      expect(stream2.isConnected).toBe(false)
+    })
+  })
+})

--- a/sdk/typescript/tsconfig.build.json
+++ b/sdk/typescript/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": ["node_modules", "dist", "tests", "**/*.test.ts"]
+}

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/sdk/typescript/vitest.config.ts
+++ b/sdk/typescript/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/index.ts'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Add TypeScript SDK (`notif.sh` on npm) for Node.js
- Add Python SDK (`notifsh` on PyPI) for Python 3.11+
- Both SDKs provide `emit()` and `subscribe()` methods with WebSocket support

## Features
- Uses `NOTIF_API_KEY` env var by default (with optional override)
- Async iterator pattern for subscriptions in both languages
- Auto-reconnect with exponential backoff
- Manual ack/nack support when `autoAck=false`
- Error types: `AuthError`, `APIError`, `ConnectionError`

## Test plan
- [x] TypeScript: 19 tests passing
- [x] Python: 16 tests passing
- [x] `make test` runs all SDK tests