### PR TITLE
Split docs: simplify README, add CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,205 @@
+# Contributing to notif.sh
+
+This guide covers self-hosting and development setup for notif.sh.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         notif.sh                            │
+│                                                             │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐   │
+│  │ REST API │  │WebSocket │  │ Webhooks │  │Dashboard │   │
+│  │  /emit   │  │   /ws    │  │  Worker  │  │  (React) │   │
+│  └────┬─────┘  └────┬─────┘  └────┬─────┘  └──────────┘   │
+│       │             │             │                        │
+│       └─────────────┼─────────────┘                        │
+│                     ▼                                       │
+│              ┌─────────────┐      ┌─────────────┐          │
+│              │    NATS     │      │  PostgreSQL │          │
+│              │ (JetStream) │      │ (metadata)  │          │
+│              └─────────────┘      └─────────────┘          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Tech Stack
+
+- **Backend**: Go, Chi router
+- **Messaging**: NATS JetStream
+- **Database**: PostgreSQL (sqlc)
+- **Frontend**: TanStack Start (React 19)
+- **Auth**: Clerk (dashboard) + API keys
+
+## Prerequisites
+
+- Go 1.21+
+- Docker and Docker Compose
+- Node.js 18+ (for frontend/SDKs)
+- Python 3.11+ (for Python SDK)
+
+## Development Setup
+
+### 1. Clone and Start Services
+
+```bash
+git clone https://github.com/filipexyz/notif.git
+cd notif
+
+# Start NATS and PostgreSQL
+make dev
+
+# Run migrations
+make migrate
+
+# Start the server
+make run
+```
+
+Server runs at `http://localhost:8080`.
+
+### 2. Create a Dev API Key
+
+```bash
+make seed
+```
+
+This creates a test key: `nsh_test_abcdefghij12345678901234`
+
+Or manually:
+
+```bash
+PGPASSWORD=notif_dev psql -h localhost -U notif -d notif -c "
+INSERT INTO api_keys (key_hash, key_prefix, name, org_id)
+VALUES (
+  encode(sha256('nsh_mydevkey12345678901234abcd'::bytea), 'hex'),
+  'nsh_mydevkey',
+  'Dev Key',
+  'org_dev'
+) RETURNING id;"
+```
+
+### 3. Test the API
+
+```bash
+curl -X POST http://localhost:8080/api/v1/emit \
+  -H "Authorization: Bearer nsh_test_abcdefghij12345678901234" \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "test", "data": {"hello": "world"}}'
+```
+
+## Make Commands
+
+```bash
+make dev          # Start NATS + Postgres (Docker)
+make run          # Run server
+make watch        # Run with hot reload (requires air)
+make build        # Build server binary
+make build-cli    # Build CLI binary
+make test         # Run all tests (Go + TypeScript + Python)
+make test-e2e     # Run e2e tests
+make migrate      # Run database migrations
+make generate     # Generate sqlc code
+make seed         # Create test API key
+```
+
+## Frontend Development
+
+```bash
+cd web
+npm install
+npm run dev   # Runs on :3000
+```
+
+Requires `CLERK_SECRET_KEY` for authentication.
+
+## Project Structure
+
+```
+notif/
+├── cmd/
+│   ├── notifd/           # Server entrypoint
+│   └── notif/            # CLI entrypoint
+├── internal/
+│   ├── server/           # HTTP server, routes
+│   ├── handler/          # Request handlers
+│   ├── middleware/       # Auth (unified, clerk)
+│   ├── nats/             # NATS JetStream
+│   ├── websocket/        # WebSocket hub
+│   ├── webhook/          # Webhook delivery
+│   ├── db/               # sqlc generated code
+│   └── domain/           # Business logic
+├── db/
+│   ├── migrations/       # Goose migrations
+│   └── queries/          # sqlc queries
+├── pkg/client/           # Go SDK
+├── sdk/
+│   ├── typescript/       # TypeScript SDK (npm: notif.sh)
+│   └── python/           # Python SDK (pip: notifsh)
+├── web/                  # Frontend (TanStack Start)
+└── tests/e2e/            # E2E tests (testcontainers)
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | Server port | `8080` |
+| `DATABASE_URL` | PostgreSQL connection | required |
+| `NATS_URL` | NATS server URL | required |
+| `CLERK_SECRET_KEY` | Clerk auth (dashboard) | optional |
+| `LOG_LEVEL` | debug, info, warn, error | `info` |
+| `LOG_FORMAT` | json, text | `json` |
+
+## API Endpoints
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/health` | Liveness check |
+| GET | `/ready` | Readiness check |
+| GET | `/ws` | WebSocket subscription |
+| POST | `/api/v1/emit` | Publish event |
+| GET | `/api/v1/events` | List events |
+| POST | `/api/v1/webhooks` | Create webhook |
+| GET | `/api/v1/webhooks` | List webhooks |
+| GET | `/api/v1/dlq` | List dead letter queue |
+| POST | `/api/v1/dlq/:seq/replay` | Replay DLQ message |
+
+## WebSocket Protocol
+
+### Subscribe
+
+```json
+{
+  "action": "subscribe",
+  "topics": ["orders.*"],
+  "options": {
+    "auto_ack": false,
+    "from": "latest",
+    "group": "worker-1"
+  }
+}
+```
+
+### Acknowledge
+
+```json
+{"action": "ack", "id": "evt_xxx"}
+{"action": "nack", "id": "evt_xxx", "retry_in": "5m"}
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Run tests (`make test`)
+4. Commit your changes
+5. Push to the branch
+6. Open a Pull Request
+
+## Publishing SDKs
+
+```bash
+make publish-ts    # Publish TypeScript SDK to npm
+make publish-py    # Publish Python SDK to PyPI
+make publish-sdks  # Publish both
+```

--- a/README.md
+++ b/README.md
@@ -2,303 +2,86 @@
 
 **Managed pub/sub for devs who don't want to manage infra.**
 
-notif.sh is an open-source event hub that centralizes events from any source and reliably delivers them to any consumer. Built for AI agents, automations, and integrations.
-
-```bash
-# Publish an event
-curl -X POST http://localhost:8080/api/v1/emit \
-  -H "Authorization: Bearer nsh_your_api_key" \
-  -H "Content-Type: application/json" \
-  -d '{"topic": "leads.new", "data": {"name": "John", "email": "john@example.com"}}'
-```
-
-## Why notif.sh?
-
-**The Problem:** Connecting events between systems is painful.
-
-- **Self-managed queues** (Redis, NATS, Kafka) require infrastructure, retry logic, dead letter handling, and custom APIs
-- **Direct webhooks** lose messages when endpoints are offline, have no built-in retry, and each integration is a new endpoint
-- **AI agents** need reliable event delivery for task assignments, status updates, and approvals
-
-**The Solution:** A simple event hub with persistence, auto-retry, dead letter queues, and real-time delivery via WebSocket or webhooks.
-
-## Features
-
-- **Topics** — Named channels with wildcard support (`leads.*`, `agent.*.error`)
-- **Publish** — Simple HTTP POST from anywhere
-- **Subscribe** — Real-time WebSocket with explicit ack/nack
-- **Webhooks** — Deliver events to HTTP endpoints with HMAC signing
-- **Persistence** — Events stored in NATS JetStream (configurable retention)
-- **Auto-retry** — Configurable backoff with max retries
-- **Dead Letter Queue** — Events that fail too many times are preserved for replay
-- **Consumer Groups** — Load-balance events across multiple instances
-- **Unified Delivery Tracking** — See all deliveries (WebSocket + webhooks) for any event
-- **Dashboard** — Web UI for monitoring events, webhooks, and DLQ
+notif.sh is an event hub that centralizes events from any source and reliably delivers them to any consumer. Built for AI agents, automations, and integrations.
 
 ## Quick Start
 
-### Prerequisites
+### 1. Get an API Key
 
-- Go 1.21+
-- Docker and Docker Compose
+Sign up at [app.notif.sh](https://app.notif.sh) to get your API key.
 
-### 1. Clone and Start
+### 2. Install
 
+**CLI (Unix)**
 ```bash
-git clone https://github.com/filipexyz/notif.git
-cd notif
-
-# Start NATS and PostgreSQL
-make dev
-
-# Run migrations
-make migrate
-
-# Start the server
-make run
+curl -fsSL https://notif.sh/install.sh | sh
+notif auth <your-api-key>
 ```
 
-The server runs at `http://localhost:8080`.
-
-### 2. Create an API Key
-
-```bash
-# Connect to the database and create a key
-PGPASSWORD=notif_dev psql -h localhost -U notif -d notif -c "
-INSERT INTO api_keys (key_hash, key_prefix, name, org_id)
-VALUES (
-  encode(sha256('nsh_mydevkey12345678901234abcd'::bytea), 'hex'),
-  'nsh_mydevkey',
-  'Dev Key',
-  'org_dev'
-) RETURNING id;"
-```
-
-Use `nsh_mydevkey12345678901234abcd` as your API key.
-
-### 3. Publish an Event
-
-```bash
-curl -X POST http://localhost:8080/api/v1/emit \
-  -H "Authorization: Bearer nsh_mydevkey12345678901234abcd" \
-  -H "Content-Type: application/json" \
-  -d '{"topic": "orders.new", "data": {"order_id": "12345", "amount": 99.99}}'
-```
-
-### 4. Subscribe via WebSocket
-
-```javascript
-const ws = new WebSocket('ws://localhost:8080/ws?token=nsh_mydevkey12345678901234abcd')
-
-ws.onopen = () => {
-  ws.send(JSON.stringify({
-    action: 'subscribe',
-    topics: ['orders.*'],
-    options: { auto_ack: false }
-  }))
-}
-
-ws.onmessage = (msg) => {
-  const data = JSON.parse(msg.data)
-  if (data.type === 'event') {
-    console.log('Received:', data.topic, data.data)
-    ws.send(JSON.stringify({ action: 'ack', id: data.id }))
-  }
-}
-```
-
-## SDKs
-
-### TypeScript / Node.js
-
+**TypeScript / Node.js**
 ```bash
 npm install notif.sh
 ```
 
-```typescript
-import { Notif } from 'notif.sh'
-
-const n = new Notif()  // Uses NOTIF_API_KEY env var
-
-// Emit
-await n.emit('leads.new', { name: 'John' })
-
-// Subscribe
-for await (const event of n.subscribe('leads.*')) {
-  console.log(event.data)
-}
-
-// Manual ack
-for await (const event of n.subscribe('leads.*', { autoAck: false })) {
-  await event.ack()
-}
-```
-
-### Python
-
+**Python**
 ```bash
 pip install notifsh
 ```
 
+### 3. Publish Events
+
+**CLI**
+```bash
+notif emit orders.new '{"order_id": "12345", "amount": 99.99}'
+```
+
+**TypeScript**
+```typescript
+import { Notif } from 'notif.sh'
+
+const n = new Notif()  // Uses NOTIF_API_KEY env var
+await n.emit('orders.new', { order_id: '12345', amount: 99.99 })
+```
+
+**Python**
 ```python
 from notifsh import Notif
 
-async with Notif() as n:  # Uses NOTIF_API_KEY env var
-    # Emit
-    await n.emit('leads.new', {'name': 'John'})
-
-    # Subscribe
-    async for event in n.subscribe('leads.*'):
-        print(event.data)
-
-    # Manual ack
-    async for event in n.subscribe('leads.*', auto_ack=False):
-        await event.ack()
+async with Notif() as n:
+    await n.emit('orders.new', {'order_id': '12345', 'amount': 99.99})
 ```
 
-## API Reference
+### 4. Subscribe to Events
 
-### Authentication
+**CLI**
+```bash
+notif subscribe 'orders.*'
+```
 
-All API requests require an API key via:
-- Header: `Authorization: Bearer nsh_xxx`
-- Query param (WebSocket): `?token=nsh_xxx`
-
-### Publish Events
-
-```http
-POST /api/v1/emit
-Content-Type: application/json
-Authorization: Bearer nsh_xxx
-
-{
-  "topic": "leads.new",
-  "data": {"name": "John", "email": "john@example.com"}
+**TypeScript**
+```typescript
+for await (const event of n.subscribe('orders.*')) {
+  console.log(event.topic, event.data)
 }
 ```
 
-**Response:**
-
-```json
-{
-  "id": "evt_abc123...",
-  "topic": "leads.new",
-  "timestamp": "2025-01-15T10:30:00Z"
-}
+**Python**
+```python
+async for event in n.subscribe('orders.*'):
+    print(event.topic, event.data)
 ```
 
-### Query Events
+## Features
 
-```http
-GET /api/v1/events?topic=leads.*&limit=100
-```
-
-### Get Event Deliveries
-
-```http
-GET /api/v1/events/{event_id}/deliveries
-```
-
-Returns all delivery attempts (WebSocket and webhooks) for an event.
-
-### Webhooks
-
-```http
-# Create webhook
-POST /api/v1/webhooks
-{
-  "url": "https://my-api.com/hook",
-  "topics": ["leads.*", "orders.>"]
-}
-
-# List webhooks
-GET /api/v1/webhooks
-
-# Update webhook
-PUT /api/v1/webhooks/{id}
-
-# Delete webhook
-DELETE /api/v1/webhooks/{id}
-```
-
-Webhook requests include HMAC-SHA256 signature in `X-Notif-Signature` header.
-
-### Dead Letter Queue
-
-```http
-# List DLQ messages
-GET /api/v1/dlq?topic=leads.*
-
-# Replay a message
-POST /api/v1/dlq/{seq}/replay
-
-# Replay all messages
-POST /api/v1/dlq/replay-all?topic=leads.*
-
-# Delete a message
-DELETE /api/v1/dlq/{seq}
-
-# Purge all
-DELETE /api/v1/dlq/purge
-```
-
-## WebSocket Protocol
-
-### Connect
-
-```
-ws://localhost:8080/ws?token=nsh_xxx
-```
-
-### Subscribe
-
-```json
-{
-  "action": "subscribe",
-  "topics": ["leads.*", "orders.>"],
-  "options": {
-    "auto_ack": false,
-    "from": "latest",
-    "group": "my-consumer-group",
-    "max_retries": 5,
-    "ack_timeout": "5m"
-  }
-}
-```
-
-| Option | Description |
-|--------|-------------|
-| `auto_ack` | Auto-acknowledge on delivery (default: `true`) |
-| `from` | Start position: `"latest"`, `"beginning"`, or ISO8601 timestamp |
-| `group` | Consumer group name for load balancing |
-| `max_retries` | Max retry attempts before DLQ (default: `5`) |
-| `ack_timeout` | Time to wait for ack before retry (default: `"5m"`) |
-
-### Receive Events
-
-```json
-{
-  "type": "event",
-  "id": "evt_abc123...",
-  "topic": "leads.new",
-  "data": {"name": "John"},
-  "timestamp": "2025-01-15T10:30:00Z",
-  "attempt": 1,
-  "max_attempts": 5
-}
-```
-
-### Acknowledge
-
-```json
-{"action": "ack", "id": "evt_abc123..."}
-```
-
-### Negative Acknowledge (retry)
-
-```json
-{"action": "nack", "id": "evt_abc123...", "retry_in": "5m"}
-```
+| Feature | Description |
+|---------|-------------|
+| **Topics** | Named channels with wildcards (`leads.*`, `orders.>`) |
+| **Publish** | Simple HTTP POST or SDK |
+| **Subscribe** | Real-time WebSocket with ack/nack |
+| **Webhooks** | HTTP delivery with HMAC signing |
+| **Auto-retry** | Exponential backoff with max retries |
+| **Dead Letter Queue** | Failed events preserved for replay |
+| **Consumer Groups** | Load-balance across instances |
 
 ## Topic Patterns
 
@@ -306,115 +89,68 @@ ws://localhost:8080/ws?token=nsh_xxx
 |---------|---------|
 | `leads.new` | Exactly `leads.new` |
 | `leads.*` | `leads.new`, `leads.qualified` (single segment) |
-| `orders.>` | `orders.new`, `orders.processing.paid` (all remaining) |
-| `agent.*.error` | `agent.search.error`, `agent.research.error` |
+| `orders.>` | `orders.new`, `orders.us.paid` (all remaining) |
 
-## Configuration
+## Manual Acknowledgment
 
-Environment variables:
+For at-least-once delivery, disable auto-ack and manually acknowledge:
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `PORT` | Server port | `8080` |
-| `DATABASE_URL` | PostgreSQL connection string | required |
-| `NATS_URL` | NATS server URL | required |
-| `CLERK_SECRET_KEY` | Clerk auth (for dashboard) | optional |
-| `LOG_LEVEL` | Log level (debug, info, warn, error) | `info` |
-| `LOG_FORMAT` | Log format (json, text) | `json` |
-| `SHUTDOWN_TIMEOUT` | Graceful shutdown timeout | `30s` |
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                         notif.sh                            │
-│                                                             │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐   │
-│  │ REST API │  │WebSocket │  │ Webhooks │  │Dashboard │   │
-│  │  /emit   │  │   /ws    │  │  Worker  │  │  (React) │   │
-│  └────┬─────┘  └────┬─────┘  └────┬─────┘  └──────────┘   │
-│       │             │             │                        │
-│       └─────────────┼─────────────┘                        │
-│                     ▼                                       │
-│              ┌─────────────┐      ┌─────────────┐          │
-│              │    NATS     │      │  PostgreSQL │          │
-│              │ (JetStream) │      │ (metadata)  │          │
-│              └─────────────┘      └─────────────┘          │
-└─────────────────────────────────────────────────────────────┘
+**TypeScript**
+```typescript
+for await (const event of n.subscribe('orders.*', { autoAck: false })) {
+  try {
+    await processOrder(event.data)
+    await event.ack()
+  } catch (err) {
+    await event.nack('5m')  // Retry in 5 minutes
+  }
+}
 ```
 
-**Tech Stack:**
-- **Backend:** Go, Chi router
-- **Messaging:** NATS JetStream
-- **Database:** PostgreSQL (sqlc for type-safe queries)
-- **Frontend:** TanStack Start (React 19 + TanStack Router)
-- **Auth:** Clerk (dashboard) + API keys (programmatic access)
+**Python**
+```python
+async for event in n.subscribe('orders.*', auto_ack=False):
+    try:
+        await process_order(event.data)
+        await event.ack()
+    except Exception:
+        await event.nack('5m')
+```
 
-## Development
+## REST API
+
+Base URL: `https://api.notif.sh`
+
+### Publish
 
 ```bash
-# Start dependencies
-make dev
-
-# Run migrations
-make migrate
-
-# Start server with hot reload
-make watch
-
-# Run tests
-make test
-
-# Run e2e tests (requires Docker)
-make test-e2e
-
-# Generate sqlc code
-make generate
-
-# Build binaries
-make build
+curl -X POST https://api.notif.sh/api/v1/emit \
+  -H "Authorization: Bearer $NOTIF_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "leads.new", "data": {"name": "John"}}'
 ```
 
-### Frontend Development
+### Webhooks
 
 ```bash
-cd web
-npm install
-npm run dev   # Runs on :3000
+# Create webhook
+curl -X POST https://api.notif.sh/api/v1/webhooks \
+  -H "Authorization: Bearer $NOTIF_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://my-api.com/hook", "topics": ["leads.*"]}'
 ```
 
-## Project Structure
+## Links
 
-```
-notif/
-├── cmd/notifd/          # Server entry point
-├── internal/
-│   ├── handler/         # HTTP handlers
-│   ├── middleware/      # Auth, logging
-│   ├── nats/            # JetStream integration
-│   ├── websocket/       # WebSocket client/hub
-│   ├── webhook/         # Webhook delivery worker
-│   └── db/              # Database queries (sqlc)
-├── db/
-│   ├── migrations/      # Goose migrations
-│   └── queries/         # SQL queries
-├── sdk/
-│   ├── typescript/      # TypeScript SDK (npm: notif.sh)
-│   └── python/          # Python SDK (pip: notifsh)
-├── web/                 # Frontend (TanStack Start)
-└── tests/e2e/           # Integration tests
-```
+- [Dashboard](https://app.notif.sh)
+- [Documentation](https://docs.notif.sh)
+- [TypeScript SDK](https://www.npmjs.com/package/notif.sh)
+- [Python SDK](https://pypi.org/project/notifsh)
 
-## Contributing
+## Self-Hosting
 
-Contributions are welcome! Please read our contributing guidelines before submitting a pull request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+notif.sh is open source. See [CONTRIBUTING.md](CONTRIBUTING.md) for self-hosting and development instructions.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT


### PR DESCRIPTION
## Summary
- Simplify README for end users (hosted service at api.notif.sh)
- Move dev/self-hosting docs to CONTRIBUTING.md

## README changes
- Focus on hosted service, not local dev
- Add CLI install via `https://notif.sh/install.sh`
- CLI, TypeScript, Python examples for emit/subscribe
- Point to api.notif.sh instead of localhost

## CONTRIBUTING.md (new)
- Architecture diagram
- Dev setup (make dev, migrate, run)
- Project structure
- Environment variables
- API endpoints reference