### PR TITLE
Use compact JSON for streaming events

### DIFF
--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -105,7 +105,9 @@ func (o *Output) JSON(data any) {
 // Event prints a formatted event.
 func (o *Output) Event(id, topic string, data json.RawMessage, ts time.Time) {
 	if o.jsonMode {
-		o.JSON(map[string]any{
+		// Compact JSON for streaming (one line per event)
+		enc := json.NewEncoder(os.Stdout)
+		enc.Encode(map[string]any{
 			"id":        id,
 			"topic":     topic,
 			"data":      json.RawMessage(data),


### PR DESCRIPTION
## Summary
- Events in `--json` mode now output as compact single-line JSON
- Enables proper parsing in shell scripts with `while read`

## Before
```json
{
  "id": "evt_xxx",
  "topic": "test.event",
  ...
}
```

## After
```json
{"id":"evt_xxx","topic":"test.event",...}
```