### PR TITLE
Fix macOS quarantine blocking binary execution

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,11 @@ fi
 
 chmod +x "$BINARY_PATH"
 
+# Clear macOS quarantine attribute to prevent Gatekeeper blocking
+if [ "$OS" = "darwin" ]; then
+    xattr -c "$BINARY_PATH" 2>/dev/null || true
+fi
+
 # Setup shell integration
 setup_path() {
     local shell_config=""


### PR DESCRIPTION
## Summary
Clear macOS quarantine attribute after downloading binary to prevent Gatekeeper from killing the process.

## Problem
On macOS, downloaded binaries get a `com.apple.quarantine` attribute that causes them to be killed (SIGKILL/exit 137) when executed.

## Fix
Add `xattr -c` after download to clear quarantine attributes.