### PR TITLE
Add request-response mode to emit CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,20 @@ async with Notif() as n:
     await n.emit('orders.new', {'order_id': '12345', 'amount': 99.99})
 ```
 
-### 4. Subscribe to Events
+### 4. Request-Response (CLI)
+
+Emit and wait for a response on another topic:
+
+```bash
+notif emit 'tasks.create' '{"task_id": "abc", "action": "process"}' \
+  --reply-to 'tasks.completed,tasks.failed' \
+  --filter '.task_id == "abc"' \
+  --timeout 60s
+```
+
+This subscribes to reply topics, emits the event, and waits for a matching response.
+
+### 5. Subscribe to Events
 
 **CLI**
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,8 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/itchyny/gojq v0.12.18 // indirect
+	github.com/itchyny/timefmt-go v0.1.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.4 h1:kEISI/Gx67NzH3nJxAmY/dGac80
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.4/go.mod h1:6Nz966r3vQYCqIzWsuEl9d7cf7mRhtDmm++sOxlnfxI=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/itchyny/gojq v0.12.18 h1:gFGHyt/MLbG9n6dqnvlliiya2TaMMh6FFaR2b1H6Drc=
+github.com/itchyny/gojq v0.12.18/go.mod h1:4hPoZ/3lN9fDL1D+aK7DY1f39XZpY9+1Xpjz8atrEkg=
+github.com/itchyny/timefmt-go v0.1.7 h1:xyftit9Tbw+Dc/huSSPJaEmX1TVL8lw5vxjJLK4GMMA=
+github.com/itchyny/timefmt-go v0.1.7/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/cli/cmd/emit.go
+++ b/internal/cli/cmd/emit.go
@@ -2,11 +2,23 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
+	"github.com/filipexyz/notif/pkg/client"
+	"github.com/itchyny/gojq"
 	"github.com/spf13/cobra"
+)
+
+var (
+	replyTo      string
+	replyFilter  string
+	replyTimeout time.Duration
 )
 
 var emitCmd = &cobra.Command{
@@ -17,7 +29,13 @@ var emitCmd = &cobra.Command{
 Examples:
   notif emit orders.created '{"id": 123}'
   echo '{"id": 123}' | notif emit orders.created
-  cat event.json | notif emit orders.created`,
+  cat event.json | notif emit orders.created
+
+Request-response mode (wait for reply):
+  notif emit orders.create '{"id": 123}' \
+    --reply-to 'orders.created,orders.failed' \
+    --filter '.id == 123' \
+    --timeout 30s`,
 	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		if cfg.APIKey == "" {
@@ -56,6 +74,14 @@ Examples:
 		}
 
 		c := getClient()
+
+		// Request-response mode
+		if replyTo != "" {
+			runRequestResponse(c, topic, json.RawMessage(data))
+			return
+		}
+
+		// Fire-and-forget mode (default)
 		resp, err := c.Emit(topic, json.RawMessage(data))
 		if err != nil {
 			if jsonOutput {
@@ -80,6 +106,127 @@ Examples:
 	},
 }
 
+func runRequestResponse(c *client.Client, topic string, data json.RawMessage) {
+	// Parse reply topics
+	topics := strings.Split(replyTo, ",")
+	for i := range topics {
+		topics[i] = strings.TrimSpace(topics[i])
+	}
+
+	// Parse jq filter if provided
+	var jqCode *gojq.Code
+	if replyFilter != "" {
+		query, err := gojq.Parse(replyFilter)
+		if err != nil {
+			out.Error("Invalid jq filter: %v", err)
+			os.Exit(1)
+		}
+		code, err := gojq.Compile(query)
+		if err != nil {
+			out.Error("Failed to compile jq filter: %v", err)
+			os.Exit(1)
+		}
+		jqCode = code
+	}
+
+	// Set up context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), replyTimeout)
+	defer cancel()
+
+	// Handle signals
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Subscribe to reply topics first
+	sub, err := c.Subscribe(ctx, topics, client.SubscribeOptions{From: "latest"})
+	if err != nil {
+		out.Error("Failed to subscribe: %v", err)
+		os.Exit(1)
+	}
+	defer sub.Close()
+
+	// Wait a bit for WebSocket connection to establish
+	time.Sleep(50 * time.Millisecond)
+
+	// Emit the request
+	resp, err := c.Emit(topic, data)
+	if err != nil {
+		out.Error("Failed to emit: %v", err)
+		os.Exit(1)
+	}
+
+	if !jsonOutput {
+		out.Success("Event emitted, waiting for response...")
+		out.KeyValue("ID", resp.ID)
+		out.KeyValue("Listening", strings.Join(topics, ", "))
+	}
+
+	// Wait for matching response
+	for {
+		select {
+		case event, ok := <-sub.Events():
+			if !ok {
+				out.Error("Subscription closed")
+				os.Exit(1)
+			}
+
+			// Check if event matches filter
+			if matchesJqFilter(jqCode, event.Data) {
+				out.Event(event.ID, event.Topic, event.Data, event.Timestamp)
+				return
+			}
+
+		case err := <-sub.Errors():
+			out.Error("Subscription error: %v", err)
+			os.Exit(1)
+
+		case <-sigCh:
+			if !jsonOutput {
+				out.Info("Interrupted")
+			}
+			os.Exit(130)
+
+		case <-ctx.Done():
+			out.Error("Timeout waiting for response")
+			os.Exit(1)
+		}
+	}
+}
+
+func matchesJqFilter(code *gojq.Code, data json.RawMessage) bool {
+	if code == nil {
+		return true // no filter = match any
+	}
+
+	var input any
+	if err := json.Unmarshal(data, &input); err != nil {
+		return false
+	}
+
+	iter := code.Run(input)
+	v, ok := iter.Next()
+	if !ok {
+		return false
+	}
+
+	// Handle error from jq
+	if err, ok := v.(error); ok {
+		_ = err
+		return false
+	}
+
+	// jq filter expressions return true/false
+	if b, ok := v.(bool); ok {
+		return b
+	}
+
+	// Non-nil result means match (for select-style filters)
+	return v != nil
+}
+
 func init() {
+	emitCmd.Flags().StringVar(&replyTo, "reply-to", "", "topics to wait for response (comma-separated)")
+	emitCmd.Flags().StringVar(&replyFilter, "filter", "", "jq expression to match response")
+	emitCmd.Flags().DurationVar(&replyTimeout, "timeout", 30*time.Second, "timeout waiting for response")
 	rootCmd.AddCommand(emitCmd)
 }


### PR DESCRIPTION
## Summary

Add `--reply-to`, `--filter`, and `--timeout` flags to `notif emit` for request-response pattern over pub/sub.

## Usage

```bash
notif emit 'agents.session.create' '{"session_id": "abc", "prompt": "Fix bug"}' \
  --reply-to 'agents.session.completed,agents.session.failed' \
  --filter '.session_id == "abc"' \
  --timeout 5m
```

## Behavior

1. Subscribe to reply topics before emitting
2. Emit the request event
3. Wait for event matching jq filter expression
4. Print matched event and exit 0
5. Exit 1 on timeout

## Changes

- `internal/cli/cmd/emit.go` - request-response logic with jq filtering
- `go.mod` / `go.sum` - added `github.com/itchyny/gojq`
- `README.md` - documented the new feature

## Test plan

- [x] Basic request-response with matching filter
- [x] Timeout when no response
- [x] Filter skips non-matching events
- [x] Invalid jq filter shows error
- [x] Fire-and-forget still works (no --reply-to)