### PR TITLE
Add filter and auto-exit to subscribe CLI

### DIFF
--- a/internal/cli/CHANGELOG.md
+++ b/internal/cli/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the notif CLI will be documented in this file.
+
+## [0.1.5] - 2026-01-03
+
+### Added
+
+- **emit**: Request-response mode with `--reply-to`, `--filter`, and `--timeout` flags
+  - Emit an event and wait for a matching response on specified topics
+  - Use jq expressions to filter responses
+  - Example: `notif emit 'tasks.create' '{"id":1}' --reply-to 'tasks.done' --filter '.id == 1' --timeout 30s`
+
+- **subscribe**: Filter and auto-exit with `--filter`, `--once`, `--count`, and `--timeout` flags
+  - Filter events using jq expressions
+  - Exit after first match (`--once`) or N matches (`--count`)
+  - Timeout if no matching events received
+  - Example: `notif subscribe 'orders.*' --filter '.amount > 100' --once --timeout 60s`
+
+## [0.1.4] - Previous
+
+- Initial CLI release with `emit`, `subscribe`, `auth`, and webhook commands

--- a/internal/cli/cmd/jq.go
+++ b/internal/cli/cmd/jq.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/itchyny/gojq"
+)
+
+// compileJqFilter parses and compiles a jq filter expression.
+func compileJqFilter(filter string) (*gojq.Code, error) {
+	query, err := gojq.Parse(filter)
+	if err != nil {
+		return nil, err
+	}
+	return gojq.Compile(query)
+}
+
+// matchesJqFilter evaluates a compiled jq filter against JSON data.
+// Returns true if the filter matches (expression evaluates to true or non-nil).
+// If code is nil, returns true (no filter = match all).
+func matchesJqFilter(code *gojq.Code, data json.RawMessage) bool {
+	if code == nil {
+		return true
+	}
+
+	var input any
+	if err := json.Unmarshal(data, &input); err != nil {
+		return false
+	}
+
+	iter := code.Run(input)
+	v, ok := iter.Next()
+	if !ok {
+		return false
+	}
+
+	// Handle error from jq
+	if _, isErr := v.(error); isErr {
+		return false
+	}
+
+	// jq filter expressions return true/false
+	if b, ok := v.(bool); ok {
+		return b
+	}
+
+	// Non-nil result means match (for select-style filters)
+	return v != nil
+}


### PR DESCRIPTION
## Summary

- Add `--filter` flag for jq expression filtering on subscribe
- Add `--once` flag to exit after first matching event
- Add `--count` flag to exit after N matching events  
- Add `--timeout` flag to timeout if no matches received
- Extract shared jq utilities to `jq.go` (used by both emit and subscribe)
- Add CLI changelog at `internal/cli/CHANGELOG.md`

## Usage

```bash
# Exit after first matching event
notif subscribe 'orders.*' --filter '.status == "completed"' --once

# Exit after 5 matching events
notif subscribe 'orders.*' --filter '.amount > 100' --count 5

# With timeout
notif subscribe 'orders.*' --filter '.order_id == "abc"' --once --timeout 30s

# Filter without auto-exit (just filters what's printed)
notif subscribe 'orders.*' --filter '.status == "completed"'
```

## Test plan

- [x] Build succeeds
- [x] `--filter` skips non-matching events
- [x] `--once` exits after first match
- [x] `--count N` exits after N matches
- [x] `--timeout` exits with error code 1 if no match