### PR TITLE
Add --raw flag to emit command

### DIFF
--- a/internal/cli/CHANGELOG.md
+++ b/internal/cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the notif CLI will be documented in this file.
 
+## [0.1.6] - 2026-01-03
+
+### Added
+
+- **emit**: `--raw` flag to output only the response data field
+  - Useful for hooks and pipes that need just the JSON payload
+  - Example: `notif emit 'request' '{}' --reply-to 'response' --raw`
+
 ## [0.1.5] - 2026-01-03
 
 ### Added

--- a/internal/cli/cmd/emit.go
+++ b/internal/cli/cmd/emit.go
@@ -21,6 +21,7 @@ var (
 	replyTo      string
 	replyFilter  string
 	replyTimeout time.Duration
+	rawOutput    bool
 )
 
 var emitCmd = &cobra.Command{
@@ -169,7 +170,13 @@ func runRequestResponse(c *client.Client, topic string, data json.RawMessage) {
 
 			// Check if event matches filter
 			if matchesJqFilter(jqCode, event.Data) {
-				out.Event(event.ID, event.Topic, event.Data, event.Timestamp)
+				if rawOutput {
+					// Output just the data field (for hooks, pipes, etc.)
+					os.Stdout.Write(event.Data)
+					os.Stdout.WriteString("\n")
+				} else {
+					out.Event(event.ID, event.Topic, event.Data, event.Timestamp)
+				}
 				return
 			}
 
@@ -194,5 +201,6 @@ func init() {
 	emitCmd.Flags().StringVar(&replyTo, "reply-to", "", "topics to wait for response (comma-separated)")
 	emitCmd.Flags().StringVar(&replyFilter, "filter", "", "jq expression to match response")
 	emitCmd.Flags().DurationVar(&replyTimeout, "timeout", 30*time.Second, "timeout waiting for response")
+	emitCmd.Flags().BoolVar(&rawOutput, "raw", false, "output only the data field (for hooks/pipes)")
 	rootCmd.AddCommand(emitCmd)
 }


### PR DESCRIPTION
## Summary

- Add `--raw` flag to `notif emit` for outputting only the response data field
- Useful for Claude Code hooks and shell pipes that need clean JSON output

## Usage

```bash
notif emit claude.permission.request '{}' \
  --reply-to claude.permission.response \
  --timeout 60s \
  --raw
```

Outputs just the data field instead of the full event details.

## Test plan

- [x] Manual test with permission hook flow