### PR TITLE
Add $input variable to emit --filter for session-based filtering

### DIFF
--- a/internal/cli/CHANGELOG.md
+++ b/internal/cli/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the notif CLI will be documented in this file.
 
+## [0.1.7] - 2026-01-03
+
+### Added
+
+- **emit**: `$input` variable in `--filter` expressions
+  - Reference the emitted request data when filtering responses
+  - Enables session-based filtering for multi-client scenarios
+  - Example: `notif emit 'request' '{"session_id":"abc"}' --reply-to 'response' --filter '.session_id == $input.session_id'`
+
 ## [0.1.6] - 2026-01-03
 
 ### Added

--- a/internal/cli/cmd/emit.go
+++ b/internal/cli/cmd/emit.go
@@ -37,8 +37,10 @@ Examples:
 Request-response mode (wait for reply):
   notif emit orders.create '{"id": 123}' \
     --reply-to 'orders.created,orders.failed' \
-    --filter '.id == 123' \
-    --timeout 30s`,
+    --filter '.id == $input.id' \
+    --timeout 30s
+
+The $input variable in --filter references the emitted request data.`,
 	Args: cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		if cfg.APIKey == "" {
@@ -168,8 +170,8 @@ func runRequestResponse(c *client.Client, topic string, data json.RawMessage) {
 				os.Exit(1)
 			}
 
-			// Check if event matches filter
-			if matchesJqFilter(jqCode, event.Data) {
+			// Check if event matches filter ($input available in filter)
+			if matchesJqFilter(jqCode, event.Data, data) {
 				if rawOutput {
 					// Output just the data field (for hooks, pipes, etc.)
 					os.Stdout.Write(event.Data)

--- a/internal/cli/cmd/subscribe.go
+++ b/internal/cli/cmd/subscribe.go
@@ -114,8 +114,8 @@ Filter and auto-exit:
 					return
 				}
 
-				// Check filter
-				if !matchesJqFilter(jqCode, event.Data) {
+				// Check filter (no $input for subscribe)
+				if !matchesJqFilter(jqCode, event.Data, nil) {
 					continue // skip non-matching events
 				}
 


### PR DESCRIPTION
## Summary
- Add `$input` variable to `--filter` expressions in `notif emit`
- Reference the emitted request data when filtering responses
- Enables session-based filtering for multi-client scenarios (e.g., Claude Code hooks)

## Example
```bash
notif emit request '{"session_id":"abc"}' \
  --reply-to response \
  --filter '.session_id == $input.session_id'
```

This ensures each client only receives responses meant for its session.

## Test plan
- [x] Tested matching session_id → response captured
- [x] Tested non-matching session_id → response ignored (times out)