### PR TITLE
fix: add CLI binary to Docker image for web terminal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ RUN go mod download
 # Copy source
 COPY . .
 
-# Build
+# Build server and CLI
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app/notifd ./cmd/notifd
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/notif ./cmd/notif
 
 # Runtime stage
 FROM alpine:3.20
@@ -27,8 +28,12 @@ RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 
 COPY --from=builder /app/notifd /app/notifd
+COPY --from=builder /app/notif /app/notif
 COPY --from=builder /go/bin/goose /usr/local/bin/goose
 COPY db/migrations /app/migrations
+
+# Set CLI path for web terminal
+ENV CLI_BINARY_PATH=/app/notif
 
 # Entrypoint script
 COPY entrypoint.sh /app/entrypoint.sh


### PR DESCRIPTION
## Summary
Adds the CLI binary to the Docker image so the web terminal can spawn it.

## Changes
- Build `notif` CLI in builder stage
- Copy to runtime image at `/app/notif`
- Set `CLI_BINARY_PATH=/app/notif` env var

## Test plan
- [ ] Deploy and verify web terminal connects without "executable not found" error