### PR TITLE
fix: default CLI path to /app/notif for Docker

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	CORSOrigins []string `env:"CORS_ORIGINS" envSeparator:"," envDefault:"http://localhost:3000,http://localhost:5173"`
 
 	// Terminal
-	CLIBinaryPath string `env:"CLI_BINARY_PATH" envDefault:"notif"`
+	CLIBinaryPath string `env:"CLI_BINARY_PATH" envDefault:"/app/notif"`
 }
 
 func Load() (*Config, error) {


### PR DESCRIPTION
Sets default CLI binary path to /app/notif so it works in Docker without needing ENV var to be picked up.