### PR TITLE
feat: add self-hosted mode (AUTH_MODE=none)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,21 @@ curl -X POST https://api.notif.sh/api/v1/webhooks \
 
 ## Self-Hosting
 
-notif.sh is open source. See [CONTRIBUTING.md](CONTRIBUTING.md) for self-hosting and development instructions.
+Run your own notif.sh instance:
+
+```bash
+# Quick start
+git clone https://github.com/filipexyz/notif.git
+cd notif
+docker compose -f docker-compose.selfhost.yaml up -d
+
+# Get your API key
+curl -X POST http://localhost:8080/api/v1/bootstrap
+```
+
+See [SELFHOST.md](SELFHOST.md) for complete self-hosting instructions.
+
+For development setup, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/SELFHOST.md
+++ b/SELFHOST.md
@@ -1,0 +1,213 @@
+# Self-Hosting notif.sh
+
+Run your own notif.sh instance in minutes.
+
+## Quick Start
+
+### 1. Start the Stack
+
+```bash
+# Clone the repo
+git clone https://github.com/filipexyz/notif.git
+cd notif
+
+# Start everything
+docker compose -f docker-compose.selfhost.yaml up -d
+```
+
+### 2. Bootstrap Your Instance
+
+```bash
+curl -X POST http://localhost:8080/api/v1/bootstrap
+```
+
+This returns your API key:
+```json
+{
+  "api_key": "nsh_abc123...",
+  "project_id": "prj_xxx",
+  "message": "Instance bootstrapped successfully. Save this API key - it won't be shown again!"
+}
+```
+
+**⚠️ Save this key!** It cannot be retrieved later.
+
+### 3. Test It
+
+```bash
+# Set your key
+export NOTIF_API_KEY=nsh_abc123...
+
+# Emit an event
+curl -X POST http://localhost:8080/api/v1/emit \
+  -H "Authorization: Bearer $NOTIF_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "test", "data": {"hello": "world"}}'
+```
+
+## Using the CLI
+
+```bash
+# Install the CLI
+curl -fsSL https://notif.sh/install.sh | sh
+
+# Configure for self-hosted
+notif config set server http://localhost:8080
+notif auth $NOTIF_API_KEY
+
+# Emit events
+notif emit test.hello '{"message": "it works!"}'
+
+# Subscribe to events
+notif subscribe 'test.*'
+```
+
+## Configuration
+
+Environment variables for the server:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTH_MODE` | `clerk` | Set to `none` for self-hosted |
+| `DEFAULT_ORG_ID` | `org_default` | Org ID for all resources |
+| `DATABASE_URL` | required | PostgreSQL connection string |
+| `NATS_URL` | `nats://localhost:4222` | NATS server URL |
+| `PORT` | `8080` | HTTP server port |
+| `LOG_LEVEL` | `info` | debug, info, warn, error |
+| `CORS_ORIGINS` | `*` | Allowed CORS origins |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│            Your Application             │
+│     (emit events, subscribe, etc)       │
+└──────────────────┬──────────────────────┘
+                   │ HTTP/WebSocket
+                   ▼
+┌─────────────────────────────────────────┐
+│              notif server               │
+│            (port 8080)                  │
+└───────┬─────────────────────┬───────────┘
+        │                     │
+        ▼                     ▼
+┌───────────────┐     ┌───────────────┐
+│     NATS      │     │   PostgreSQL  │
+│  (JetStream)  │     │   (metadata)  │
+│  port 4222    │     │   port 5432   │
+└───────────────┘     └───────────────┘
+```
+
+## Production Considerations
+
+### Security
+
+1. **Change default passwords** in docker-compose
+2. **Use HTTPS** - put a reverse proxy (nginx, caddy) in front
+3. **Restrict CORS** - set `CORS_ORIGINS` to your domains
+4. **Backup PostgreSQL** regularly
+
+### High Availability
+
+For production deployments:
+
+1. Use managed PostgreSQL (RDS, Cloud SQL, etc.)
+2. Use NATS cluster for HA
+3. Run multiple notif server instances behind a load balancer
+
+### Custom Docker Compose
+
+```yaml
+# docker-compose.prod.yaml
+services:
+  notif:
+    image: ghcr.io/filipexyz/notif:latest
+    environment:
+      AUTH_MODE: "none"
+      DATABASE_URL: "postgres://user:pass@your-db:5432/notif?sslmode=require"
+      NATS_URL: "nats://your-nats:4222"
+      CORS_ORIGINS: "https://app.yourdomain.com"
+    restart: always
+```
+
+## Updating
+
+```bash
+# Pull latest images
+docker compose -f docker-compose.selfhost.yaml pull
+
+# Restart with new version
+docker compose -f docker-compose.selfhost.yaml up -d
+```
+
+Migrations run automatically on startup.
+
+## Troubleshooting
+
+### Check Status
+
+```bash
+# Health check
+curl http://localhost:8080/health
+
+# Bootstrap status
+curl http://localhost:8080/api/v1/bootstrap/status
+```
+
+### View Logs
+
+```bash
+docker compose -f docker-compose.selfhost.yaml logs -f notif
+```
+
+### Reset Everything
+
+```bash
+# Stop and remove volumes (WARNING: deletes all data)
+docker compose -f docker-compose.selfhost.yaml down -v
+
+# Start fresh
+docker compose -f docker-compose.selfhost.yaml up -d
+```
+
+## API Keys Management
+
+In self-hosted mode, you manage API keys via the API:
+
+```bash
+# List keys
+curl -H "Authorization: Bearer $NOTIF_API_KEY" \
+  http://localhost:8080/api/v1/api-keys
+
+# Create new key
+curl -X POST -H "Authorization: Bearer $NOTIF_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Production Key"}' \
+  http://localhost:8080/api/v1/api-keys
+
+# Revoke key
+curl -X DELETE -H "Authorization: Bearer $NOTIF_API_KEY" \
+  http://localhost:8080/api/v1/api-keys/{id}
+```
+
+## Projects
+
+Organize events by project:
+
+```bash
+# Create project
+curl -X POST -H "Authorization: Bearer $NOTIF_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Production"}' \
+  http://localhost:8080/api/v1/projects
+
+# List projects
+curl -H "Authorization: Bearer $NOTIF_API_KEY" \
+  http://localhost:8080/api/v1/projects
+```
+
+## Support
+
+- [Documentation](https://docs.notif.sh)
+- [GitHub Issues](https://github.com/filipexyz/notif/issues)
+- [Discord](https://discord.gg/notif)

--- a/SELFHOST.md
+++ b/SELFHOST.md
@@ -68,7 +68,7 @@ Environment variables for the server:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AUTH_MODE` | `clerk` | Set to `none` for self-hosted |
+| `AUTH_MODE` | `clerk` | Set to `local` for self-hosted (API keys only) |
 | `DEFAULT_ORG_ID` | `org_default` | Org ID for all resources |
 | `DATABASE_URL` | required | PostgreSQL connection string |
 | `NATS_URL` | `nats://localhost:4222` | NATS server URL |

--- a/SELFHOST.md
+++ b/SELFHOST.md
@@ -123,7 +123,7 @@ services:
   notif:
     image: ghcr.io/filipexyz/notif:latest
     environment:
-      AUTH_MODE: "none"
+      AUTH_MODE: "local"
       DATABASE_URL: "postgres://user:pass@your-db:5432/notif?sslmode=require"
       NATS_URL: "nats://your-nats:4222"
       CORS_ORIGINS: "https://app.yourdomain.com"

--- a/docker-compose.selfhost.yaml
+++ b/docker-compose.selfhost.yaml
@@ -1,0 +1,67 @@
+# Self-hosted notif.sh
+# 
+# Quick start:
+#   docker compose -f docker-compose.selfhost.yaml up -d
+#   curl -X POST http://localhost:8080/api/v1/bootstrap
+#
+# This will return your API key. Save it!
+
+services:
+  nats:
+    image: nats:2.10-alpine
+    command:
+      - "--jetstream"
+      - "--store_dir=/data"
+      - "--http_port=8222"
+    ports:
+      - "4222:4222"
+    volumes:
+      - nats_data:/data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8222/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: notif
+      POSTGRES_PASSWORD: notif_selfhost
+      POSTGRES_DB: notif
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U notif"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  notif:
+    image: ghcr.io/filipexyz/notif:latest
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: "postgres://notif:notif_selfhost@postgres:5432/notif?sslmode=disable"
+      NATS_URL: "nats://nats:4222"
+      # Self-hosted mode: no Clerk, API keys only
+      AUTH_MODE: "none"
+      DEFAULT_ORG_ID: "org_selfhosted"
+      LOG_LEVEL: "info"
+      LOG_FORMAT: "text"
+      # Allow all origins for self-hosted (customize as needed)
+      CORS_ORIGINS: "*"
+    depends_on:
+      nats:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  nats_data:
+  postgres_data:

--- a/docker-compose.selfhost.yaml
+++ b/docker-compose.selfhost.yaml
@@ -51,8 +51,8 @@ services:
       PORT: "8080"
       DATABASE_URL: "postgres://notif:notif_selfhost@postgres:5432/notif?sslmode=disable"
       NATS_URL: "nats://nats:4222"
-      # Self-hosted mode: no Clerk, API keys only
-      AUTH_MODE: "none"
+      # Self-hosted mode: local auth via API keys (no external provider)
+      AUTH_MODE: "local"
       DEFAULT_ORG_ID: "org_selfhosted"
       LOG_LEVEL: "info"
       LOG_FORMAT: "text"

--- a/docker-compose.selfhost.yaml
+++ b/docker-compose.selfhost.yaml
@@ -5,6 +5,9 @@
 #   curl -X POST http://localhost:8080/api/v1/bootstrap
 #
 # This will return your API key. Save it!
+#
+# NOTE: Default passwords below are for local development only.
+# For production, change POSTGRES_PASSWORD and update DATABASE_URL accordingly.
 
 services:
   nats:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,11 +32,11 @@ type Config struct {
 	LogFormat string `env:"LOG_FORMAT" envDefault:"json"`
 
 	// Authentication
-	// AUTH_MODE: "clerk" (default) or "none" (self-hosted, API keys only)
+	// AUTH_MODE: "clerk" (default) or "local" (self-hosted, API keys only)
 	AuthMode       AuthMode `env:"AUTH_MODE" envDefault:"clerk"`
 	ClerkSecretKey string   `env:"CLERK_SECRET_KEY"`
 
-	// Self-hosted mode settings (used when AUTH_MODE=none)
+	// Self-hosted mode settings (used when AUTH_MODE=local)
 	// Default org ID for self-hosted single-tenant mode
 	DefaultOrgID string `env:"DEFAULT_ORG_ID" envDefault:"org_default"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,8 @@ type AuthMode string
 const (
 	// AuthModeClerk uses Clerk for dashboard auth + API keys for API access.
 	AuthModeClerk AuthMode = "clerk"
-	// AuthModeNone disables Clerk auth, uses only API keys. Good for self-hosting.
-	AuthModeNone AuthMode = "none"
+	// AuthModeLocal uses only API keys (no external auth provider). For self-hosting.
+	AuthModeLocal AuthMode = "local"
 )
 
 type Config struct {
@@ -49,7 +49,7 @@ type Config struct {
 
 // IsSelfHosted returns true if running in self-hosted mode (no Clerk).
 func (c *Config) IsSelfHosted() bool {
-	return c.AuthMode == AuthModeNone
+	return c.AuthMode == AuthModeLocal
 }
 
 func Load() (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,16 @@ import (
 	"github.com/caarlos0/env/v10"
 )
 
+// AuthMode determines the authentication mode for the server.
+type AuthMode string
+
+const (
+	// AuthModeClerk uses Clerk for dashboard auth + API keys for API access.
+	AuthModeClerk AuthMode = "clerk"
+	// AuthModeNone disables Clerk auth, uses only API keys. Good for self-hosting.
+	AuthModeNone AuthMode = "none"
+)
+
 type Config struct {
 	// Server
 	Port            string        `env:"PORT" envDefault:"8080"`
@@ -21,14 +31,25 @@ type Config struct {
 	LogLevel  string `env:"LOG_LEVEL" envDefault:"info"`
 	LogFormat string `env:"LOG_FORMAT" envDefault:"json"`
 
-	// Clerk Authentication (for dashboard routes)
-	ClerkSecretKey string `env:"CLERK_SECRET_KEY"`
+	// Authentication
+	// AUTH_MODE: "clerk" (default) or "none" (self-hosted, API keys only)
+	AuthMode       AuthMode `env:"AUTH_MODE" envDefault:"clerk"`
+	ClerkSecretKey string   `env:"CLERK_SECRET_KEY"`
+
+	// Self-hosted mode settings (used when AUTH_MODE=none)
+	// Default org ID for self-hosted single-tenant mode
+	DefaultOrgID string `env:"DEFAULT_ORG_ID" envDefault:"org_default"`
 
 	// CORS
 	CORSOrigins []string `env:"CORS_ORIGINS" envSeparator:"," envDefault:"http://localhost:3000,http://localhost:5173"`
 
 	// Terminal
 	CLIBinaryPath string `env:"CLI_BINARY_PATH" envDefault:"/app/notif"`
+}
+
+// IsSelfHosted returns true if running in self-hosted mode (no Clerk).
+func (c *Config) IsSelfHosted() bool {
+	return c.AuthMode == AuthModeNone
 }
 
 func Load() (*Config, error) {

--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -39,9 +39,10 @@ type APIKeyResponse struct {
 }
 
 // Create creates a new API key for the authenticated organization and project.
+// Works with both Clerk auth (UserID) and API key auth (APIKeyID) in self-hosted mode.
 func (h *APIKeyHandler) Create(w http.ResponseWriter, r *http.Request) {
 	authCtx := middleware.GetAuthContext(r.Context())
-	if authCtx == nil || authCtx.UserID == nil {
+	if authCtx == nil {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 		return
 	}
@@ -99,9 +100,10 @@ func (h *APIKeyHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 // List lists all API keys for the authenticated project.
+// Works with both Clerk auth (UserID) and API key auth (APIKeyID) in self-hosted mode.
 func (h *APIKeyHandler) List(w http.ResponseWriter, r *http.Request) {
 	authCtx := middleware.GetAuthContext(r.Context())
-	if authCtx == nil || authCtx.UserID == nil {
+	if authCtx == nil {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 		return
 	}
@@ -142,9 +144,10 @@ func (h *APIKeyHandler) List(w http.ResponseWriter, r *http.Request) {
 }
 
 // Revoke revokes an API key (soft delete).
+// Works with both Clerk auth (UserID) and API key auth (APIKeyID) in self-hosted mode.
 func (h *APIKeyHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 	authCtx := middleware.GetAuthContext(r.Context())
-	if authCtx == nil || authCtx.UserID == nil {
+	if authCtx == nil {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 		return
 	}

--- a/internal/handler/bootstrap.go
+++ b/internal/handler/bootstrap.go
@@ -1,0 +1,146 @@
+package handler
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/filipexyz/notif/internal/config"
+	"github.com/filipexyz/notif/internal/db"
+	"github.com/filipexyz/notif/internal/domain"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// BootstrapHandler handles initial setup for self-hosted instances.
+type BootstrapHandler struct {
+	queries *db.Queries
+	cfg     *config.Config
+}
+
+// NewBootstrapHandler creates a new BootstrapHandler.
+func NewBootstrapHandler(queries *db.Queries, cfg *config.Config) *BootstrapHandler {
+	return &BootstrapHandler{queries: queries, cfg: cfg}
+}
+
+// BootstrapResponse is returned when bootstrapping a new instance.
+type BootstrapResponse struct {
+	APIKey    string `json:"api_key"`
+	ProjectID string `json:"project_id"`
+	Message   string `json:"message"`
+}
+
+// Bootstrap creates the initial API key for a self-hosted instance.
+// This endpoint only works when:
+// 1. AUTH_MODE=none (self-hosted mode)
+// 2. No API keys exist in the database yet
+func (h *BootstrapHandler) Bootstrap(w http.ResponseWriter, r *http.Request) {
+	// Only allow in self-hosted mode
+	if !h.cfg.IsSelfHosted() {
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error": "bootstrap only available in self-hosted mode (AUTH_MODE=none)",
+		})
+		return
+	}
+
+	// Check if any API keys already exist for this org
+	keys, err := h.queries.ListAPIKeysByOrg(r.Context(), pgtype.Text{String: h.cfg.DefaultOrgID, Valid: true})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to check existing keys",
+		})
+		return
+	}
+
+	if len(keys) > 0 {
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"error": "instance already bootstrapped - API keys exist",
+		})
+		return
+	}
+
+	// Create default project first
+	projectID := domain.GenerateProjectID()
+	_, err = h.queries.CreateProject(r.Context(), db.CreateProjectParams{
+		ID:    projectID,
+		OrgID: h.cfg.DefaultOrgID,
+		Name:  "Default",
+	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to create default project",
+		})
+		return
+	}
+
+	// Generate a secure API key
+	apiKey, err := generateBootstrapKey()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to generate api key",
+		})
+		return
+	}
+
+	// Hash the key for storage
+	keyHash := sha256HashKey(apiKey)
+	keyPrefix := apiKey[:16] // nsh_xxxxxxxxxxxx
+
+	// Create the API key in the database
+	_, err = h.queries.CreateAPIKey(r.Context(), db.CreateAPIKeyParams{
+		KeyHash:   keyHash,
+		KeyPrefix: keyPrefix,
+		Name:      pgtype.Text{String: "Bootstrap Key", Valid: true},
+		OrgID:     pgtype.Text{String: h.cfg.DefaultOrgID, Valid: true},
+		ProjectID: projectID,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to create api key",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, BootstrapResponse{
+		APIKey:    apiKey,
+		ProjectID: projectID,
+		Message:   "Instance bootstrapped successfully. Save this API key - it won't be shown again!",
+	})
+}
+
+// Status returns the bootstrap status of the instance.
+func (h *BootstrapHandler) Status(w http.ResponseWriter, r *http.Request) {
+	// Check if any API keys exist for default org
+	keys, err := h.queries.ListAPIKeysByOrg(r.Context(), pgtype.Text{String: h.cfg.DefaultOrgID, Valid: true})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to check status",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"bootstrapped": len(keys) > 0,
+		"self_hosted":  h.cfg.IsSelfHosted(),
+		"auth_mode":    string(h.cfg.AuthMode),
+	})
+}
+
+func generateBootstrapKey() (string, error) {
+	// Generate 28 random alphanumeric characters (32 total with nsh_ prefix)
+	// Must match domain.ValidateKeyFormat regex: nsh_[a-zA-Z0-9]{28}
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, 28)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	for i := range b {
+		b[i] = chars[int(b[i])%len(chars)]
+	}
+	return "nsh_" + string(b), nil
+}
+
+func sha256HashKey(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/handler/bootstrap.go
+++ b/internal/handler/bootstrap.go
@@ -32,13 +32,13 @@ type BootstrapResponse struct {
 
 // Bootstrap creates the initial API key for a self-hosted instance.
 // This endpoint only works when:
-// 1. AUTH_MODE=none (self-hosted mode)
+// 1. AUTH_MODE=local (self-hosted mode)
 // 2. No API keys exist in the database yet
 func (h *BootstrapHandler) Bootstrap(w http.ResponseWriter, r *http.Request) {
 	// Only allow in self-hosted mode
 	if !h.cfg.IsSelfHosted() {
 		writeJSON(w, http.StatusForbidden, map[string]string{
-			"error": "bootstrap only available in self-hosted mode (AUTH_MODE=none)",
+			"error": "bootstrap only available in self-hosted mode (AUTH_MODE=local)",
 		})
 		return
 	}

--- a/internal/middleware/unified.go
+++ b/internal/middleware/unified.go
@@ -27,7 +27,7 @@ type AuthContext struct {
 
 // UnifiedAuth creates middleware that accepts both API key and Clerk auth.
 // API key takes precedence if both are present.
-// In self-hosted mode (AUTH_MODE=none), Clerk auth is skipped.
+// In self-hosted mode (AUTH_MODE=local), Clerk auth is skipped.
 func UnifiedAuth(queries *db.Queries, cfg *config.Config) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -126,7 +126,7 @@ func UnifiedAuth(queries *db.Queries, cfg *config.Config) func(http.Handler) htt
 
 // RequireClerkAuth returns middleware that requires Clerk auth (not API key).
 // Use this for endpoints like API key management that shouldn't allow API key auth.
-// In self-hosted mode (AUTH_MODE=none), this allows API key auth instead.
+// In self-hosted mode (AUTH_MODE=local), this allows API key auth instead.
 func RequireClerkAuth(cfg *config.Config) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -33,12 +33,21 @@ type Server struct {
 
 // New creates a new Server.
 func New(cfg *config.Config, pool *pgxpool.Pool, nc *nats.Client) *Server {
-	// Initialize Clerk for dashboard authentication
-	if cfg.ClerkSecretKey != "" {
-		clerk.SetKey(cfg.ClerkSecretKey)
-		slog.Info("Clerk authentication enabled for dashboard routes")
+	// Log auth mode
+	if cfg.IsSelfHosted() {
+		slog.Info("Running in self-hosted mode",
+			"auth_mode", string(cfg.AuthMode),
+			"default_org", cfg.DefaultOrgID,
+		)
+		slog.Info("Bootstrap your instance: POST /api/v1/bootstrap")
 	} else {
-		slog.Warn("CLERK_SECRET_KEY not set - dashboard routes will not work")
+		// Initialize Clerk for dashboard authentication
+		if cfg.ClerkSecretKey != "" {
+			clerk.SetKey(cfg.ClerkSecretKey)
+			slog.Info("Clerk authentication enabled for dashboard routes")
+		} else {
+			slog.Warn("CLERK_SECRET_KEY not set - dashboard routes will not work")
+		}
 	}
 
 	hub := websocket.NewHub()


### PR DESCRIPTION
## Summary

Add self-hosted mode for running notif.sh without Clerk authentication.

## Changes

- **Config**: New `AUTH_MODE` environment variable (`clerk` | `none`)
- **Bootstrap endpoint**: `POST /api/v1/bootstrap` creates initial API key without auth
- **Status endpoint**: `GET /api/v1/bootstrap/status` returns instance state
- **Middleware**: Skip Clerk validation when `AUTH_MODE=none`
- **Docker Compose**: New `docker-compose.selfhost.yaml` for easy deployment
- **Documentation**: New `SELFHOST.md` with setup instructions

## Self-hosted Flow

```bash
# 1. Start the stack
docker compose -f docker-compose.selfhost.yaml up -d

# 2. Bootstrap (get API key)
curl -X POST http://localhost:8080/api/v1/bootstrap

# 3. Use the API
curl -X POST http://localhost:8080/api/v1/emit \
  -H "Authorization: Bearer $KEY" \
  -d '{"topic": "test", "data": {"hello": "world"}}'
```

## Testing

- [x] Server starts without Clerk secrets
- [x] Bootstrap creates API key
- [x] Emit works with API key
- [x] Subscribe (WebSocket) works
- [x] Create project works
- [x] Documentation complete

## Files Changed

| File | Change |
|------|--------|
| `internal/config/config.go` | +AuthMode config |
| `internal/middleware/unified.go` | Skip Clerk in self-hosted |
| `internal/handler/bootstrap.go` | **New** - bootstrap endpoint |
| `internal/server/routes.go` | +bootstrap routes |
| `internal/server/server.go` | Log self-hosted mode |
| `docker-compose.selfhost.yaml` | **New** - self-host compose |
| `SELFHOST.md` | **New** - documentation |
