### PR TITLE
feat(web): add custom server connection

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -131,7 +131,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -600,7 +599,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -644,7 +642,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2503,7 +2500,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
       "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -2536,7 +2532,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.16.tgz",
       "integrity": "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.16"
       },
@@ -2553,7 +2548,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.144.0.tgz",
       "integrity": "sha512-GmRyIGmHtGj3VLTHXepIwXAxTcHyL5W7Vw7O1CnVEtFxQQWKMVOnWgI7tPY6FhlNwMKVb3n0mPFWz9KMYyd2GA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.141.0",
         "@tanstack/react-store": "^0.8.0",
@@ -2629,7 +2623,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-start/-/react-start-1.145.3.tgz",
       "integrity": "sha512-ZRd0VbcpPSmYTGdR7PF5LdyPnB7rd4zfyuf8bjtUbjphh4P0wjE3DUTA7Mk29RMvvo6sS7Advjsax9ZqEevLgg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/react-router": "1.144.0",
         "@tanstack/react-start-client": "1.145.0",
@@ -2724,7 +2717,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.144.0.tgz",
       "integrity": "sha512-6oVERtK9XDHCP4XojgHsdHO56ZSj11YaWjF5g/zw39LhyA6Lx+/X86AEIHO4y0BUrMQaJfcjdAQMVSAs6Vjtdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.141.0",
         "@tanstack/store": "^0.8.0",
@@ -3024,7 +3016,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3159,7 +3150,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3169,7 +3159,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3179,7 +3168,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3545,7 +3533,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3740,7 +3727,6 @@
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.1.tgz",
       "integrity": "sha512-E7WKBcHVhAVrY6JYD5kteNqVq1GSZxqGrdSiwXR9at+XHi43HJoCQKXcCczR5LBnBquFZPsB3o7HklulKoBU5w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "srvx": ">=0.7.1"
       },
@@ -3822,8 +3808,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "6.0.0",
@@ -3844,7 +3829,6 @@
       "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
       "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@electric-sql/pglite": "*",
         "@libsql/client": "*",
@@ -4958,12 +4942,41 @@
         }
       }
     },
+    "node_modules/nitro/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nitro/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/nitro/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -5117,8 +5130,7 @@
       "version": "2.0.0-alpha.3",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
       "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ohash": {
       "version": "2.0.11",
@@ -5340,7 +5352,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5350,7 +5361,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5448,7 +5458,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
       "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5530,7 +5539,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.4.2.tgz",
       "integrity": "sha512-N3HEHRCZYn3cQbsC4B5ldj9j+tHdf4JZoYPlcI4rRYu0Xy4qN8MQf1Z08EibzB0WpgRG5BGK08FTrmM66eSzKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5572,7 +5580,6 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.10.tgz",
       "integrity": "sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.3.0",
@@ -5584,7 +5591,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
       "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5894,7 +5900,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5993,7 +5998,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/web/src/components/auth/ServerConnect.tsx
+++ b/web/src/components/auth/ServerConnect.tsx
@@ -1,0 +1,284 @@
+import { useState } from 'react'
+import { SignInButton } from '@clerk/tanstack-react-start'
+import { useServer, ServerConfig } from '../../lib/server-context'
+
+export function ServerConnect() {
+  const { connect, testConnection, savedServers, isLoading } = useServer()
+  const [mode, setMode] = useState<'select' | 'cloud' | 'self-hosted'>('select')
+  const [serverUrl, setServerUrl] = useState('http://localhost:8080')
+  const [apiKey, setApiKey] = useState('')
+  const [serverName, setServerName] = useState('')
+  const [testing, setTesting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [testSuccess, setTestSuccess] = useState(false)
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-neutral-50">
+        <div className="text-neutral-500">Loading...</div>
+      </div>
+    )
+  }
+
+  const handleTestConnection = async () => {
+    setTesting(true)
+    setError(null)
+    setTestSuccess(false)
+
+    const config: ServerConfig = {
+      type: 'self-hosted',
+      url: serverUrl.replace(/\/$/, ''), // Remove trailing slash
+      apiKey,
+      name: serverName || serverUrl,
+    }
+
+    const result = await testConnection(config)
+    setTesting(false)
+
+    if (result.ok) {
+      setTestSuccess(true)
+    } else {
+      setError(result.error || 'Connection failed')
+    }
+  }
+
+  const handleConnectSelfHosted = async () => {
+    setTesting(true)
+    setError(null)
+
+    const config: ServerConfig = {
+      type: 'self-hosted',
+      url: serverUrl.replace(/\/$/, ''),
+      apiKey,
+      name: serverName || serverUrl,
+    }
+
+    const success = await connect(config)
+    setTesting(false)
+
+    if (!success) {
+      setError('Failed to connect. Please check URL and API key.')
+    }
+  }
+
+  const handleConnectToSaved = async (config: ServerConfig) => {
+    setTesting(true)
+    setError(null)
+    const success = await connect(config)
+    setTesting(false)
+    if (!success) {
+      setError('Failed to connect to saved server')
+    }
+  }
+
+  // Selection screen
+  if (mode === 'select') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-neutral-50">
+        <div className="w-full max-w-md p-8">
+          <div className="text-center mb-8">
+            <h1 className="text-3xl font-bold text-neutral-900 mb-2">notif.sh</h1>
+            <p className="text-neutral-500">Managed pub/sub event hub</p>
+          </div>
+
+          <div className="space-y-3">
+            <button
+              onClick={() => setMode('cloud')}
+              className="w-full p-4 text-left bg-white border border-neutral-200 hover:border-primary-500 hover:bg-primary-50 transition-colors group"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-2xl">☁️</span>
+                <div>
+                  <div className="font-medium text-neutral-900 group-hover:text-primary-600">
+                    notif.sh Cloud
+                  </div>
+                  <div className="text-sm text-neutral-500">
+                    Managed service — sign in with your account
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            <button
+              onClick={() => setMode('self-hosted')}
+              className="w-full p-4 text-left bg-white border border-neutral-200 hover:border-primary-500 hover:bg-primary-50 transition-colors group"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-2xl">🏠</span>
+                <div>
+                  <div className="font-medium text-neutral-900 group-hover:text-primary-600">
+                    Self-hosted server
+                  </div>
+                  <div className="text-sm text-neutral-500">
+                    Connect to your own notif.sh instance
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            {savedServers.length > 0 && (
+              <div className="pt-4 border-t border-neutral-200 mt-4">
+                <div className="text-xs font-medium text-neutral-400 uppercase tracking-wide mb-2">
+                  Recent servers
+                </div>
+                {savedServers.map((server) => (
+                  <button
+                    key={server.url}
+                    onClick={() => handleConnectToSaved(server)}
+                    disabled={testing}
+                    className="w-full p-3 text-left bg-white border border-neutral-200 hover:border-primary-500 hover:bg-primary-50 transition-colors mb-2 last:mb-0"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span>{server.type === 'cloud' ? '☁️' : '🏠'}</span>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium text-neutral-900 truncate">
+                          {server.name || server.url}
+                        </div>
+                        <div className="text-xs text-neutral-500 truncate">{server.url}</div>
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {error && (
+            <div className="mt-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  // Cloud sign-in
+  if (mode === 'cloud') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-neutral-50">
+        <div className="w-full max-w-md p-8">
+          <button
+            onClick={() => setMode('select')}
+            className="text-neutral-500 hover:text-neutral-700 mb-6 flex items-center gap-1"
+          >
+            ← Back
+          </button>
+
+          <div className="text-center">
+            <div className="text-4xl mb-4">☁️</div>
+            <h1 className="text-2xl font-semibold text-neutral-900 mb-2">notif.sh Cloud</h1>
+            <p className="text-neutral-500 mb-8">Sign in to access your events and webhooks</p>
+            
+            <SignInButton mode="modal">
+              <button className="w-full px-6 py-3 bg-primary-500 text-white font-medium hover:bg-primary-600 transition-colors">
+                Sign in with Clerk
+              </button>
+            </SignInButton>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Self-hosted connection
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-neutral-50">
+      <div className="w-full max-w-md p-8">
+        <button
+          onClick={() => setMode('select')}
+          className="text-neutral-500 hover:text-neutral-700 mb-6 flex items-center gap-1"
+        >
+          ← Back
+        </button>
+
+        <div className="text-center mb-8">
+          <div className="text-4xl mb-4">🏠</div>
+          <h1 className="text-2xl font-semibold text-neutral-900 mb-2">Self-hosted server</h1>
+          <p className="text-neutral-500">Connect to your own notif.sh instance</p>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">
+              Server URL
+            </label>
+            <input
+              type="url"
+              value={serverUrl}
+              onChange={(e) => {
+                setServerUrl(e.target.value)
+                setTestSuccess(false)
+                setError(null)
+              }}
+              placeholder="http://localhost:8080"
+              className="w-full px-3 py-2 border border-neutral-300 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 outline-none"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">
+              API Key
+            </label>
+            <input
+              type="password"
+              value={apiKey}
+              onChange={(e) => {
+                setApiKey(e.target.value)
+                setTestSuccess(false)
+                setError(null)
+              }}
+              placeholder="nsh_..."
+              className="w-full px-3 py-2 border border-neutral-300 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 outline-none font-mono"
+            />
+            <p className="text-xs text-neutral-500 mt-1">
+              Get your API key from <code className="bg-neutral-100 px-1">POST /api/v1/bootstrap</code>
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 mb-1">
+              Name <span className="text-neutral-400">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={serverName}
+              onChange={(e) => setServerName(e.target.value)}
+              placeholder="My local server"
+              className="w-full px-3 py-2 border border-neutral-300 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 outline-none"
+            />
+          </div>
+
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          {testSuccess && (
+            <div className="p-3 bg-green-50 border border-green-200 text-green-700 text-sm">
+              ✓ Connection successful!
+            </div>
+          )}
+
+          <div className="flex gap-3 pt-2">
+            <button
+              onClick={handleTestConnection}
+              disabled={testing || !serverUrl || !apiKey}
+              className="flex-1 px-4 py-2.5 border border-neutral-300 text-neutral-700 font-medium hover:bg-neutral-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {testing ? 'Testing...' : 'Test Connection'}
+            </button>
+            <button
+              onClick={handleConnectSelfHosted}
+              disabled={testing || !serverUrl || !apiKey}
+              className="flex-1 px-4 py-2.5 bg-primary-500 text-white font-medium hover:bg-primary-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {testing ? 'Connecting...' : 'Connect'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/auth/ServerConnect.tsx
+++ b/web/src/components/auth/ServerConnect.tsx
@@ -2,9 +2,15 @@ import { useState } from 'react'
 import { SignInButton } from '@clerk/tanstack-react-start'
 import { useServer, ServerConfig } from '../../lib/server-context'
 
+// Check if Clerk is configured
+const CLERK_AVAILABLE = !!import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
 export function ServerConnect() {
   const { connect, testConnection, savedServers, isLoading } = useServer()
-  const [mode, setMode] = useState<'select' | 'cloud' | 'self-hosted'>('select')
+  // If Clerk not configured, skip to self-hosted directly
+  const [mode, setMode] = useState<'select' | 'cloud' | 'self-hosted'>(
+    CLERK_AVAILABLE ? 'select' : 'self-hosted'
+  )
   const [serverUrl, setServerUrl] = useState('http://localhost:8080')
   const [apiKey, setApiKey] = useState('')
   const [serverName, setServerName] = useState('')
@@ -82,22 +88,24 @@ export function ServerConnect() {
           </div>
 
           <div className="space-y-3">
-            <button
-              onClick={() => setMode('cloud')}
-              className="w-full p-4 text-left bg-white border border-neutral-200 hover:border-primary-500 hover:bg-primary-50 transition-colors group"
-            >
-              <div className="flex items-center gap-3">
-                <span className="text-2xl">☁️</span>
-                <div>
-                  <div className="font-medium text-neutral-900 group-hover:text-primary-600">
-                    notif.sh Cloud
-                  </div>
-                  <div className="text-sm text-neutral-500">
-                    Managed service — sign in with your account
+            {CLERK_AVAILABLE && (
+              <button
+                onClick={() => setMode('cloud')}
+                className="w-full p-4 text-left bg-white border border-neutral-200 hover:border-primary-500 hover:bg-primary-50 transition-colors group"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-2xl">☁️</span>
+                  <div>
+                    <div className="font-medium text-neutral-900 group-hover:text-primary-600">
+                      notif.sh Cloud
+                    </div>
+                    <div className="text-sm text-neutral-500">
+                      Managed service — sign in with your account
+                    </div>
                   </div>
                 </div>
-              </div>
-            </button>
+              </button>
+            )}
 
             <button
               onClick={() => setMode('self-hosted')}

--- a/web/src/components/layout/TopNav.tsx
+++ b/web/src/components/layout/TopNav.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "@tanstack/react-router";
 import { UserButton } from "@clerk/tanstack-react-start";
 import { Badge } from "../ui/Badge";
 import { ProjectSelector } from "./ProjectSelector";
+import { useServer } from "../../lib/server-context";
 
 const navItems = [
   { href: "/", label: "Events" },
@@ -18,6 +19,7 @@ interface TopNavProps {
 
 export function TopNav({ dlqCount = 0 }: TopNavProps) {
   const location = useLocation();
+  const { server, disconnect } = useServer();
 
   return (
     <header className="h-12 border-b border-neutral-200 bg-white">
@@ -66,7 +68,16 @@ export function TopNav({ dlqCount = 0 }: TopNavProps) {
 
         {/* Right side */}
         <div className="flex items-center gap-3">
-          <UserButton afterSignOutUrl="/" />
+          {server?.type === 'self-hosted' ? (
+            <button
+              onClick={disconnect}
+              className="px-3 py-1.5 text-sm font-medium text-neutral-600 hover:text-neutral-900 hover:bg-neutral-50 transition-colors"
+            >
+              Disconnect
+            </button>
+          ) : (
+            <UserButton afterSignOutUrl="/" />
+          )}
         </div>
       </div>
     </header>

--- a/web/src/components/terminal/WebTerminal.tsx
+++ b/web/src/components/terminal/WebTerminal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { useAuth } from '@clerk/tanstack-react-start'
+import { useAuth } from '../../lib/auth'
 import type { Terminal as TerminalType } from '@xterm/xterm'
 import type { FitAddon as FitAddonType } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { useAuth } from '@clerk/tanstack-react-start'
+import { useAuth } from './auth'
 import { useProjectId, useProject } from './project-context'
 import { useServer, useServerUrl, useServerApiKey } from './server-context'
 

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,29 @@
+// Re-export useAuth from Clerk or mock based on availability
+// Components should import useAuth from here, not directly from Clerk
+
+import { useAuth as useClerkAuth } from '@clerk/tanstack-react-start'
+import { useMockAuth } from './clerk-mock'
+import { useServer } from './server-context'
+
+/**
+ * Universal useAuth hook that works in both cloud and self-hosted modes.
+ * - In cloud mode: uses real Clerk auth
+ * - In self-hosted mode: uses mock auth (returns noop implementations)
+ * 
+ * Note: This must be called within either ClerkProvider or MockClerkProvider
+ */
+export function useAuth() {
+  const { server } = useServer()
+  
+  // In self-hosted mode, we're inside MockClerkProvider
+  // In cloud mode, we're inside ClerkProvider
+  // Both provide their respective useAuth implementations
+  
+  if (server?.type === 'self-hosted') {
+    return useMockAuth()
+  }
+  
+  // Cloud mode - use real Clerk auth
+  // This is safe because we're wrapped in ClerkProvider
+  return useClerkAuth()
+}

--- a/web/src/lib/clerk-auth-provider.tsx
+++ b/web/src/lib/clerk-auth-provider.tsx
@@ -1,0 +1,26 @@
+// Clerk auth provider that bridges Clerk's useAuth to our AuthContext
+// Used in cloud mode to provide real Clerk authentication
+
+import { ReactNode } from 'react'
+import { useAuth as useClerkAuth } from '@clerk/tanstack-react-start'
+import { AuthContext } from './auth'
+
+export function ClerkAuthProvider({ children }: { children: ReactNode }) {
+  const clerkAuth = useClerkAuth()
+  
+  const authValue = {
+    isLoaded: clerkAuth.isLoaded,
+    isSignedIn: clerkAuth.isSignedIn ?? false,
+    userId: clerkAuth.userId ?? null,
+    sessionId: clerkAuth.sessionId ?? null,
+    orgId: clerkAuth.orgId ?? null,
+    getToken: clerkAuth.getToken,
+    signOut: clerkAuth.signOut,
+  }
+  
+  return (
+    <AuthContext.Provider value={authValue}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/web/src/lib/clerk-mock.tsx
+++ b/web/src/lib/clerk-mock.tsx
@@ -1,0 +1,56 @@
+// Mock Clerk context for self-hosted mode
+// Provides the same hooks as Clerk but with noop implementations
+
+import { createContext, useContext, ReactNode } from 'react'
+
+interface MockAuthContextValue {
+  isLoaded: boolean
+  isSignedIn: boolean
+  userId: string | null
+  sessionId: string | null
+  orgId: string | null
+  getToken: () => Promise<string | null>
+  signOut: () => Promise<void>
+}
+
+const MockAuthContext = createContext<MockAuthContextValue>({
+  isLoaded: true,
+  isSignedIn: true, // Treat self-hosted as "signed in" via API key
+  userId: 'self-hosted-user',
+  sessionId: 'self-hosted-session',
+  orgId: 'self-hosted-org',
+  getToken: async () => null,
+  signOut: async () => {},
+})
+
+export function MockClerkProvider({ children }: { children: ReactNode }) {
+  return (
+    <MockAuthContext.Provider
+      value={{
+        isLoaded: true,
+        isSignedIn: true,
+        userId: 'self-hosted-user',
+        sessionId: 'self-hosted-session',
+        orgId: 'self-hosted-org',
+        getToken: async () => null,
+        signOut: async () => {},
+      }}
+    >
+      {children}
+    </MockAuthContext.Provider>
+  )
+}
+
+export function useMockAuth() {
+  return useContext(MockAuthContext)
+}
+
+// Mock SignedIn component - always renders children
+export function MockSignedIn({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}
+
+// Mock SignedOut component - never renders children
+export function MockSignedOut({ children }: { children: ReactNode }) {
+  return null
+}

--- a/web/src/lib/clerk-mock.tsx
+++ b/web/src/lib/clerk-mock.tsx
@@ -1,19 +1,11 @@
 // Mock Clerk context for self-hosted mode
-// Provides the same hooks as Clerk but with noop implementations
+// Provides the same interface as Clerk but with noop implementations
 
-import { createContext, useContext, ReactNode } from 'react'
+import { ReactNode } from 'react'
+import { AuthContext } from './auth'
 
-interface MockAuthContextValue {
-  isLoaded: boolean
-  isSignedIn: boolean
-  userId: string | null
-  sessionId: string | null
-  orgId: string | null
-  getToken: () => Promise<string | null>
-  signOut: () => Promise<void>
-}
-
-const MockAuthContext = createContext<MockAuthContextValue>({
+// Self-hosted auth values
+const selfHostedAuth = {
   isLoaded: true,
   isSignedIn: true, // Treat self-hosted as "signed in" via API key
   userId: 'self-hosted-user',
@@ -21,36 +13,12 @@ const MockAuthContext = createContext<MockAuthContextValue>({
   orgId: 'self-hosted-org',
   getToken: async () => null,
   signOut: async () => {},
-})
+}
 
-export function MockClerkProvider({ children }: { children: ReactNode }) {
+export function MockAuthProvider({ children }: { children: ReactNode }) {
   return (
-    <MockAuthContext.Provider
-      value={{
-        isLoaded: true,
-        isSignedIn: true,
-        userId: 'self-hosted-user',
-        sessionId: 'self-hosted-session',
-        orgId: 'self-hosted-org',
-        getToken: async () => null,
-        signOut: async () => {},
-      }}
-    >
+    <AuthContext.Provider value={selfHostedAuth}>
       {children}
-    </MockAuthContext.Provider>
+    </AuthContext.Provider>
   )
-}
-
-export function useMockAuth() {
-  return useContext(MockAuthContext)
-}
-
-// Mock SignedIn component - always renders children
-export function MockSignedIn({ children }: { children: ReactNode }) {
-  return <>{children}</>
-}
-
-// Mock SignedOut component - never renders children
-export function MockSignedOut({ children }: { children: ReactNode }) {
-  return null
 }

--- a/web/src/lib/server-context.tsx
+++ b/web/src/lib/server-context.tsx
@@ -1,0 +1,194 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+
+export interface ServerConfig {
+  type: 'cloud' | 'self-hosted'
+  url: string
+  apiKey?: string
+  name?: string
+}
+
+const DEFAULT_CLOUD_SERVER: ServerConfig = {
+  type: 'cloud',
+  url: import.meta.env.VITE_API_URL || 'https://api.notif.sh',
+  name: 'notif.sh Cloud',
+}
+
+const STORAGE_KEY = 'notif_server_config'
+
+interface ServerContextValue {
+  server: ServerConfig | null
+  isConnected: boolean
+  isLoading: boolean
+  savedServers: ServerConfig[]
+  connect: (config: ServerConfig) => Promise<boolean>
+  disconnect: () => void
+  testConnection: (config: ServerConfig) => Promise<{ ok: boolean; error?: string }>
+  saveServer: (config: ServerConfig) => void
+  removeServer: (url: string) => void
+}
+
+const ServerContext = createContext<ServerContextValue | null>(null)
+
+export function useServer() {
+  const ctx = useContext(ServerContext)
+  if (!ctx) {
+    throw new Error('useServer must be used within ServerProvider')
+  }
+  return ctx
+}
+
+export function useServerUrl() {
+  const { server } = useServer()
+  return server?.url || DEFAULT_CLOUD_SERVER.url
+}
+
+export function useServerApiKey() {
+  const { server } = useServer()
+  return server?.apiKey
+}
+
+interface StoredData {
+  currentServer: ServerConfig | null
+  savedServers: ServerConfig[]
+}
+
+function loadFromStorage(): StoredData {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      return JSON.parse(stored)
+    }
+  } catch (e) {
+    console.error('Failed to load server config from localStorage', e)
+  }
+  return { currentServer: null, savedServers: [] }
+}
+
+function saveToStorage(data: StoredData) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  } catch (e) {
+    console.error('Failed to save server config to localStorage', e)
+  }
+}
+
+export function ServerProvider({ children }: { children: ReactNode }) {
+  const [server, setServer] = useState<ServerConfig | null>(null)
+  const [savedServers, setSavedServers] = useState<ServerConfig[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    const { currentServer, savedServers: saved } = loadFromStorage()
+    setServer(currentServer)
+    setSavedServers(saved)
+    setIsLoading(false)
+  }, [])
+
+  // Save to localStorage on change
+  useEffect(() => {
+    if (!isLoading) {
+      saveToStorage({ currentServer: server, savedServers })
+    }
+  }, [server, savedServers, isLoading])
+
+  const testConnection = async (config: ServerConfig): Promise<{ ok: boolean; error?: string }> => {
+    try {
+      const headers: Record<string, string> = {}
+      if (config.apiKey) {
+        headers['Authorization'] = `Bearer ${config.apiKey}`
+      }
+      
+      // Try health endpoint first (no auth needed)
+      const healthRes = await fetch(`${config.url}/health`, { 
+        method: 'GET',
+        headers,
+      })
+      
+      if (!healthRes.ok) {
+        return { ok: false, error: `Server returned ${healthRes.status}` }
+      }
+
+      // For self-hosted, verify API key works
+      if (config.type === 'self-hosted' && config.apiKey) {
+        const statusRes = await fetch(`${config.url}/api/v1/bootstrap/status`, {
+          method: 'GET',
+          headers,
+        })
+        
+        if (!statusRes.ok) {
+          return { ok: false, error: 'Failed to verify server status' }
+        }
+
+        const status = await statusRes.json()
+        if (!status.self_hosted) {
+          return { ok: false, error: 'Server is not in self-hosted mode' }
+        }
+
+        // Test API key by listing events
+        const eventsRes = await fetch(`${config.url}/api/v1/events?limit=1`, {
+          method: 'GET',
+          headers,
+        })
+
+        if (!eventsRes.ok) {
+          return { ok: false, error: 'Invalid API key' }
+        }
+      }
+
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : 'Connection failed' }
+    }
+  }
+
+  const connect = async (config: ServerConfig): Promise<boolean> => {
+    const result = await testConnection(config)
+    if (result.ok) {
+      setServer(config)
+      return true
+    }
+    return false
+  }
+
+  const disconnect = () => {
+    setServer(null)
+  }
+
+  const saveServer = (config: ServerConfig) => {
+    setSavedServers(prev => {
+      const existing = prev.findIndex(s => s.url === config.url)
+      if (existing >= 0) {
+        const updated = [...prev]
+        updated[existing] = config
+        return updated
+      }
+      return [...prev, config]
+    })
+  }
+
+  const removeServer = (url: string) => {
+    setSavedServers(prev => prev.filter(s => s.url !== url))
+    if (server?.url === url) {
+      setServer(null)
+    }
+  }
+
+  return (
+    <ServerContext.Provider
+      value={{
+        server,
+        isConnected: server !== null,
+        isLoading,
+        savedServers,
+        connect,
+        disconnect,
+        testConnection,
+        saveServer,
+        removeServer,
+      }}
+    >
+      {children}
+    </ServerContext.Provider>
+  )
+}

--- a/web/src/lib/websocket.ts
+++ b/web/src/lib/websocket.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { useAuth } from '@clerk/tanstack-react-start'
+import { useAuth } from './auth'
 import { useServer, useServerUrl, useServerApiKey } from './server-context'
 import type { StoredEvent } from './types'
 

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,14 +1,14 @@
 import { HeadContent, Outlet, Scripts, createRootRoute } from '@tanstack/react-router'
-import { ClerkProvider, SignedIn, SignedOut, useAuth } from '@clerk/tanstack-react-start'
+import { ClerkProvider, SignedIn, SignedOut } from '@clerk/tanstack-react-start'
 import { QueryClientProvider } from '@tanstack/react-query'
-import { ReactNode } from 'react'
 
 import { TopNav } from '../components/layout/TopNav'
 import { ServerConnect } from '../components/auth/ServerConnect'
 import { queryClient } from '../lib/query'
 import { ServerProvider, useServer } from '../lib/server-context'
 import { ProjectProvider } from '../lib/project-context'
-import { MockClerkProvider, MockSignedIn } from '../lib/clerk-mock'
+import { MockAuthProvider } from '../lib/clerk-mock'
+import { ClerkAuthProvider } from '../lib/clerk-auth-provider'
 
 import appCss from '../styles.css?url'
 
@@ -68,7 +68,7 @@ function SelfHostedApp() {
   const { server } = useServer()
   
   return (
-    <MockClerkProvider>
+    <MockAuthProvider>
       <ProjectProvider>
         <AppContent />
         <div className="fixed bottom-4 right-4 px-3 py-1.5 bg-amber-100 text-amber-800 text-xs font-medium flex items-center gap-2">
@@ -76,15 +76,18 @@ function SelfHostedApp() {
           <span>{server?.name || server?.url}</span>
         </div>
       </ProjectProvider>
-    </MockClerkProvider>
+    </MockAuthProvider>
   )
 }
 
-function AuthenticatedApp() {
+// Cloud app with Clerk - needs ClerkAuthProvider bridge
+function CloudAuthenticatedApp() {
   return (
-    <ProjectProvider>
-      <AppContent />
-    </ProjectProvider>
+    <ClerkAuthProvider>
+      <ProjectProvider>
+        <AppContent />
+      </ProjectProvider>
+    </ClerkAuthProvider>
   )
 }
 
@@ -119,7 +122,7 @@ function ServerRouter() {
   return (
     <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
       <SignedIn>
-        <AuthenticatedApp />
+        <CloudAuthenticatedApp />
       </SignedIn>
       <SignedOut>
         <ServerConnect />


### PR DESCRIPTION
## Summary

Add ability to connect to self-hosted notif.sh servers from the web dashboard.

## UX

Landing page now shows server selection:
- **notif.sh Cloud** - sign in with Clerk (existing flow)
- **Self-hosted server** - connect with URL + API key

Pattern inspired by Bitwarden, Element (Matrix), and Mastodon clients.

## Changes

| File | Change |
|------|--------|
| `web/src/lib/server-context.tsx` | **New** - Server connection state management |
| `web/src/components/auth/ServerConnect.tsx` | **New** - Server selection UI |
| `web/src/routes/__root.tsx` | Integrate ServerProvider, show ServerConnect |
| `web/src/lib/api.ts` | Use server URL from context |
| `web/src/lib/websocket.ts` | Use server URL from context |

## Features

- [x] Choose between Cloud and Self-hosted on landing
- [x] Input Server URL and API Key for self-hosted
- [x] Test Connection button validates server
- [x] Persist server config in localStorage
- [x] Save multiple servers for quick access
- [x] API requests use selected server
- [x] WebSocket uses selected server
- [x] Visual indicator when connected to self-hosted

## Testing

1. Run web app: `cd web && npm run dev`
2. Select "Self-hosted server"
3. Enter URL (`http://localhost:8080`) and API key
4. Click "Test Connection" then "Connect"
5. Verify dashboard loads events from self-hosted server

## Screenshots

_TODO: Add screenshots of the new server selection UI_
