### PR TITLE
fix(web): use default URL for cloud mode and skip connection test

### DIFF
--- a/web/src/lib/server-context.tsx
+++ b/web/src/lib/server-context.tsx
@@ -143,6 +143,16 @@ export function ServerProvider({ children }: { children: ReactNode }) {
   }
 
   const connect = async (config: ServerConfig): Promise<boolean> => {
+    // For cloud mode, use default URL and skip connection test (Clerk handles auth)
+    if (config.type === 'cloud') {
+      setServer({
+        ...DEFAULT_CLOUD_SERVER,
+        ...config,
+      })
+      return true
+    }
+    
+    // For self-hosted, test connection first
     const result = await testConnection(config)
     if (result.ok) {
       setServer(config)


### PR DESCRIPTION
## Problem

Auto-connect to cloud failing because `connect({ type: 'cloud' })` was called without URL, causing `testConnection` to fail.

Console errors in prod:
```
422 Unprocessable Entity
404 Not Found  
```

## Root Cause

`connect()` always called `testConnection(config)`, but for cloud mode:
1. No URL was provided in config
2. `testConnection` tried to fetch from undefined URL
3. Requests failed → connect returned false → auto-connect didn't work

## Solution

For cloud mode:
1. Use `DEFAULT_CLOUD_SERVER.url` automatically
2. Skip `testConnection` (Clerk handles auth)

```tsx
const connect = async (config: ServerConfig): Promise<boolean> => {
  if (config.type === 'cloud') {
    setServer({
      ...DEFAULT_CLOUD_SERVER,  // ← Auto URL
      ...config,
    })
    return true  // ← Skip test
  }
  // Self-hosted: test connection first
  ...
}
```

## Testing

- [x] Code review by spoc
- [ ] Manual test in prod by Luís

