### PR TITLE
feat(web): add server switcher dropdown in header

### DIFF
--- a/web/src/components/layout/ServerSwitcher.tsx
+++ b/web/src/components/layout/ServerSwitcher.tsx
@@ -1,0 +1,101 @@
+import { useState, useRef, useEffect } from 'react'
+import { useServer } from '../../lib/server-context'
+
+export function ServerSwitcher() {
+  const { server, savedServers, connect, disconnect } = useServer()
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const handleSwitchServer = () => {
+    disconnect()
+    setIsOpen(false)
+  }
+
+  const serverLabel = server?.type === 'cloud' 
+    ? 'notif.sh' 
+    : (server?.name || server?.url || 'Server')
+
+  const serverIcon = server?.type === 'cloud' ? '☁️' : '🏠'
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-2 py-1 text-sm text-neutral-600 hover:text-neutral-900 hover:bg-neutral-50 rounded transition-colors"
+      >
+        <span>{serverIcon}</span>
+        <span className="max-w-[150px] truncate">{serverLabel}</span>
+        <svg
+          className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full left-0 mt-1 w-64 bg-white border border-neutral-200 shadow-lg z-50">
+          {/* Current server */}
+          <div className="px-3 py-2 border-b border-neutral-100">
+            <div className="text-xs font-medium text-neutral-400 uppercase tracking-wide mb-1">
+              Connected to
+            </div>
+            <div className="flex items-center gap-2">
+              <span>{serverIcon}</span>
+              <span className="font-medium text-neutral-900 truncate">{serverLabel}</span>
+              <span className="ml-auto text-green-500">●</span>
+            </div>
+          </div>
+
+          {/* Saved servers */}
+          {savedServers.length > 0 && (
+            <div className="py-1 border-b border-neutral-100">
+              <div className="px-3 py-1 text-xs font-medium text-neutral-400 uppercase tracking-wide">
+                Saved Servers
+              </div>
+              {savedServers
+                .filter(s => s.url !== server?.url)
+                .map((s, i) => (
+                  <button
+                    key={i}
+                    onClick={() => {
+                      connect(s)
+                      setIsOpen(false)
+                    }}
+                    className="w-full px-3 py-2 text-left text-sm hover:bg-neutral-50 flex items-center gap-2"
+                  >
+                    <span>{s.type === 'cloud' ? '☁️' : '🏠'}</span>
+                    <span className="truncate">{s.name || s.url || 'notif.sh'}</span>
+                  </button>
+                ))}
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="py-1">
+            <button
+              onClick={handleSwitchServer}
+              className="w-full px-3 py-2 text-left text-sm text-neutral-600 hover:bg-neutral-50 flex items-center gap-2"
+            >
+              <span>🔄</span>
+              <span>Switch Server</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/layout/TopNav.tsx
+++ b/web/src/components/layout/TopNav.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "@tanstack/react-router";
 import { UserButton } from "@clerk/tanstack-react-start";
 import { Badge } from "../ui/Badge";
 import { ProjectSelector } from "./ProjectSelector";
+import { ServerSwitcher } from "./ServerSwitcher";
 import { useServer } from "../../lib/server-context";
 
 const navItems = [
@@ -19,7 +20,7 @@ interface TopNavProps {
 
 export function TopNav({ dlqCount = 0 }: TopNavProps) {
   const location = useLocation();
-  const { server, disconnect } = useServer();
+  const { server } = useServer();
 
   return (
     <header className="h-12 border-b border-neutral-200 bg-white">
@@ -31,6 +32,11 @@ export function TopNav({ dlqCount = 0 }: TopNavProps) {
               notif.sh
             </Link>
             <Badge className="bg-primary-100 text-primary-700">beta</Badge>
+          </div>
+
+          {/* Server Switcher */}
+          <div className="border-l border-neutral-200 pl-4">
+            <ServerSwitcher />
           </div>
 
           {/* Project Selector */}
@@ -69,12 +75,9 @@ export function TopNav({ dlqCount = 0 }: TopNavProps) {
         {/* Right side */}
         <div className="flex items-center gap-3">
           {server?.type === 'self-hosted' ? (
-            <button
-              onClick={disconnect}
-              className="px-3 py-1.5 text-sm font-medium text-neutral-600 hover:text-neutral-900 hover:bg-neutral-50 transition-colors"
-            >
-              Disconnect
-            </button>
+            <div className="flex items-center gap-2 text-sm text-neutral-500">
+              <span>API Key</span>
+            </div>
           ) : (
             <UserButton afterSignOutUrl="/" />
           )}


### PR DESCRIPTION
## Feature

Add server switcher dropdown to header, allowing users to switch between cloud and self-hosted servers without clearing localStorage.

## UI

```
☁️ notif.sh  ▼
├── Connected to
│   └── ☁️ notif.sh ●
├── Saved Servers
│   └── 🏠 localhost:8080
└── 🔄 Switch Server
```

## Changes

| File | Change |
|------|--------|
| `ServerSwitcher.tsx` | **New** - Dropdown component |
| `TopNav.tsx` | Add ServerSwitcher, simplify right side |

## Features

- [x] Shows current server with icon (☁️/🏠)
- [x] Lists saved servers for quick switch
- [x] "Switch Server" disconnects and shows ServerConnect
- [x] Click outside closes dropdown
- [x] Truncates long server names

## Testing

- [x] Build passes
- [x] Code review by spoc
- [ ] Visual test (rate limited on Clerk)

Luís to test in prod.
