### PR TITLE
fix(web): prevent auto-reconnect after manual disconnect

### DIFF
--- a/web/src/lib/server-context.tsx
+++ b/web/src/lib/server-context.tsx
@@ -20,6 +20,7 @@ interface ServerContextValue {
   isConnected: boolean
   isLoading: boolean
   savedServers: ServerConfig[]
+  manualDisconnect: boolean
   connect: (config: ServerConfig) => Promise<boolean>
   disconnect: () => void
   testConnection: (config: ServerConfig) => Promise<{ ok: boolean; error?: string }>
@@ -76,6 +77,7 @@ export function ServerProvider({ children }: { children: ReactNode }) {
   const [server, setServer] = useState<ServerConfig | null>(null)
   const [savedServers, setSavedServers] = useState<ServerConfig[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [manualDisconnect, setManualDisconnect] = useState(false)
 
   // Load from localStorage on mount
   useEffect(() => {
@@ -143,6 +145,9 @@ export function ServerProvider({ children }: { children: ReactNode }) {
   }
 
   const connect = async (config: ServerConfig): Promise<boolean> => {
+    // Clear manual disconnect flag when connecting
+    setManualDisconnect(false)
+    
     // For cloud mode, use default URL and skip connection test (Clerk handles auth)
     if (config.type === 'cloud') {
       setServer({
@@ -162,6 +167,8 @@ export function ServerProvider({ children }: { children: ReactNode }) {
   }
 
   const disconnect = () => {
+    // Set flag to prevent auto-reconnect
+    setManualDisconnect(true)
     setServer(null)
   }
 
@@ -191,6 +198,7 @@ export function ServerProvider({ children }: { children: ReactNode }) {
         isConnected: server !== null,
         isLoading,
         savedServers,
+        manualDisconnect,
         connect,
         disconnect,
         testConnection,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -107,15 +107,15 @@ function MaybeClerkProvider({ children }: { children: ReactNode }) {
 // Auto-connect to cloud when user is already signed in with Clerk
 function AutoConnectIfSignedIn() {
   const { isSignedIn, isLoaded } = useAuth()
-  const { connect, isConnected } = useServer()
+  const { connect, isConnected, manualDisconnect } = useServer()
 
   useEffect(() => {
     // If user is signed in with Clerk but not connected to a server,
-    // automatically connect to cloud
-    if (isLoaded && isSignedIn && !isConnected) {
+    // automatically connect to cloud (unless user manually disconnected)
+    if (isLoaded && isSignedIn && !isConnected && !manualDisconnect) {
       connect({ type: 'cloud' })
     }
-  }, [isLoaded, isSignedIn, isConnected, connect])
+  }, [isLoaded, isSignedIn, isConnected, manualDisconnect, connect])
 
   return null
 }


### PR DESCRIPTION
## Problem

When user clicks 'Switch Server', `disconnect()` sets `server = null`, but `AutoConnectIfSignedIn` immediately reconnects because it sees `!isConnected && isSignedIn`.

## Solution

Add `manualDisconnect` flag:

```tsx
const disconnect = () => {
  setManualDisconnect(true)  // ← Prevent auto-reconnect
  setServer(null)
}

// AutoConnectIfSignedIn
if (isLoaded && isSignedIn && !isConnected && !manualDisconnect) {
  connect({ type: 'cloud' })
}
```

When user connects to a server, flag is cleared.

## Testing

- [x] Build passes
- [ ] spoc to test 'Switch Server' works

