### PR TITLE
fix(web): pass ServerConfig object to testConnection

### DIFF
--- a/web/src/components/auth/ServerConnect.tsx
+++ b/web/src/components/auth/ServerConnect.tsx
@@ -31,7 +31,11 @@ export function ServerConnect() {
     setError(null)
     setTestSuccess(false)
 
-    const result = await testConnection(serverUrl, apiKey)
+    const result = await testConnection({
+      type: 'self-hosted',
+      url: serverUrl,
+      apiKey,
+    })
     
     setTesting(false)
     if (result.success) {


### PR DESCRIPTION
## Bug

`testConnection` was being called with separate params instead of a `ServerConfig` object:

```tsx
// Before (wrong)
testConnection(serverUrl, apiKey)

// After (correct)
testConnection({
  type: 'self-hosted',
  url: serverUrl,
  apiKey,
})
```

This caused the connection test to fail because `config.url` was undefined.

## Testing

- [x] Build passes

Luís to test in prod.
