### PR TITLE
fix(web): check result.ok instead of result.success

### DIFF
--- a/web/src/components/auth/ServerConnect.tsx
+++ b/web/src/components/auth/ServerConnect.tsx
@@ -38,7 +38,7 @@ export function ServerConnect() {
     })
     
     setTesting(false)
-    if (result.success) {
+    if (result.ok) {
       setTestSuccess(true)
     } else {
       setError(result.error || 'Connection failed')


### PR DESCRIPTION
## Bug

`testConnection` returns `{ ok: boolean, error?: string }` but the code was checking `result.success`:

```tsx
// testConnection returns:
{ ok: boolean, error?: string }

// Code was checking:
if (result.success)  // ← always undefined/falsy

// Fixed to:
if (result.ok)  // ← correct field
```

This caused Test Connection to never show success.
