### PR TITLE
fix(web): persistence and Sign In after Switch Server

### DIFF
--- a/web/src/components/auth/ServerConnect.tsx
+++ b/web/src/components/auth/ServerConnect.tsx
@@ -6,7 +6,7 @@ import { useServer, ServerConfig } from '../../lib/server-context'
 const CLERK_AVAILABLE = !!import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
 export function ServerConnect() {
-  const { connect, testConnection, savedServers, isLoading } = useServer()
+  const { connect, testConnection, savedServers, isLoading, clearManualDisconnect } = useServer()
   // If Clerk not configured, skip to self-hosted directly
   const [mode, setMode] = useState<'select' | 'cloud' | 'self-hosted'>(
     CLERK_AVAILABLE ? 'select' : 'self-hosted'
@@ -72,7 +72,10 @@ export function ServerConnect() {
           <div className="space-y-3">
             {CLERK_AVAILABLE && (
               <button
-                onClick={() => setMode('cloud')}
+                onClick={() => {
+                  clearManualDisconnect()  // Allow auto-connect after Sign In
+                  setMode('cloud')
+                }}
                 className="w-full p-4 text-left bg-white border border-neutral-200 hover:border-primary-500 hover:bg-primary-50 transition-colors group"
               >
                 <div className="flex items-center gap-3">

--- a/web/src/lib/server-context.tsx
+++ b/web/src/lib/server-context.tsx
@@ -23,6 +23,7 @@ interface ServerContextValue {
   manualDisconnect: boolean
   connect: (config: ServerConfig) => Promise<boolean>
   disconnect: () => void
+  clearManualDisconnect: () => void
   testConnection: (config: ServerConfig) => Promise<{ ok: boolean; error?: string }>
   saveServer: (config: ServerConfig) => void
   removeServer: (url: string) => void
@@ -172,6 +173,10 @@ export function ServerProvider({ children }: { children: ReactNode }) {
     setServer(null)
   }
 
+  const clearManualDisconnect = () => {
+    setManualDisconnect(false)
+  }
+
   const saveServer = (config: ServerConfig) => {
     setSavedServers(prev => {
       const existing = prev.findIndex(s => s.url === config.url)
@@ -201,6 +206,7 @@ export function ServerProvider({ children }: { children: ReactNode }) {
         manualDisconnect,
         connect,
         disconnect,
+        clearManualDisconnect,
         testConnection,
         saveServer,
         removeServer,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -107,15 +107,16 @@ function MaybeClerkProvider({ children }: { children: ReactNode }) {
 // Auto-connect to cloud when user is already signed in with Clerk
 function AutoConnectIfSignedIn() {
   const { isSignedIn, isLoaded } = useAuth()
-  const { connect, isConnected, manualDisconnect } = useServer()
+  const { connect, isConnected, manualDisconnect, isLoading } = useServer()
 
   useEffect(() => {
+    // Wait for localStorage to load before auto-connecting
     // If user is signed in with Clerk but not connected to a server,
     // automatically connect to cloud (unless user manually disconnected)
-    if (isLoaded && isSignedIn && !isConnected && !manualDisconnect) {
+    if (isLoaded && !isLoading && isSignedIn && !isConnected && !manualDisconnect) {
       connect({ type: 'cloud' })
     }
-  }, [isLoaded, isSignedIn, isConnected, manualDisconnect, connect])
+  }, [isLoaded, isLoading, isSignedIn, isConnected, manualDisconnect, connect])
 
   return null
 }


### PR DESCRIPTION
## Problems Fixed

### 1. Server config not persisting on refresh

`AutoConnectIfSignedIn` was auto-connecting before localStorage finished loading:

```tsx
// Before: didn't check isLoading
if (isLoaded && isSignedIn && !isConnected && !manualDisconnect) {
  connect({ type: 'cloud' })  // ← overwrites saved self-hosted server
}

// After: waits for localStorage
if (isLoaded && !isLoading && isSignedIn && !isConnected && !manualDisconnect) {
  connect({ type: 'cloud' })
}
```

### 2. Sign In not working after Switch Server

When user clicked 'Switch Server' then tried to Sign In to Cloud:
- `manualDisconnect` was `true`, blocking auto-connect

Fix: When user selects Cloud mode, clear the flag:

```tsx
onClick={() => {
  clearManualDisconnect()  // Allow auto-connect after Sign In
  setMode('cloud')
}}
```
