### PR TITLE
feat(web): ServerConnect as closeable modal

### DIFF
--- a/web/src/components/layout/ServerSwitcher.tsx
+++ b/web/src/components/layout/ServerSwitcher.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useServer } from '../../lib/server-context'
 
 export function ServerSwitcher() {
-  const { server, savedServers, connect, disconnect } = useServer()
+  const { server, savedServers, connect, openServerModal } = useServer()
   const [isOpen, setIsOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
@@ -18,7 +18,7 @@ export function ServerSwitcher() {
   }, [])
 
   const handleSwitchServer = () => {
-    disconnect()
+    openServerModal()
     setIsOpen(false)
   }
 

--- a/web/src/lib/server-context.tsx
+++ b/web/src/lib/server-context.tsx
@@ -21,9 +21,12 @@ interface ServerContextValue {
   isLoading: boolean
   savedServers: ServerConfig[]
   manualDisconnect: boolean
+  showServerModal: boolean
   connect: (config: ServerConfig) => Promise<boolean>
   disconnect: () => void
   clearManualDisconnect: () => void
+  openServerModal: () => void
+  closeServerModal: () => void
   testConnection: (config: ServerConfig) => Promise<{ ok: boolean; error?: string }>
   saveServer: (config: ServerConfig) => void
   removeServer: (url: string) => void
@@ -79,6 +82,7 @@ export function ServerProvider({ children }: { children: ReactNode }) {
   const [savedServers, setSavedServers] = useState<ServerConfig[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [manualDisconnect, setManualDisconnect] = useState(false)
+  const [showServerModal, setShowServerModal] = useState(false)
 
   // Load from localStorage on mount
   useEffect(() => {
@@ -177,6 +181,14 @@ export function ServerProvider({ children }: { children: ReactNode }) {
     setManualDisconnect(false)
   }
 
+  const openServerModal = () => {
+    setShowServerModal(true)
+  }
+
+  const closeServerModal = () => {
+    setShowServerModal(false)
+  }
+
   const saveServer = (config: ServerConfig) => {
     setSavedServers(prev => {
       const existing = prev.findIndex(s => s.url === config.url)
@@ -204,9 +216,12 @@ export function ServerProvider({ children }: { children: ReactNode }) {
         isLoading,
         savedServers,
         manualDisconnect,
+        showServerModal,
         connect,
         disconnect,
         clearManualDisconnect,
+        openServerModal,
+        closeServerModal,
         testConnection,
         saveServer,
         removeServer,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -121,6 +121,15 @@ function AutoConnectIfSignedIn() {
   return null
 }
 
+// Modal overlay for switching servers while connected
+function ServerModal() {
+  const { showServerModal, closeServerModal } = useServer()
+  
+  if (!showServerModal) return null
+  
+  return <ServerConnect isModal onClose={closeServerModal} />
+}
+
 // Inner router that decides what to show based on server selection
 function ServerRouter() {
   const { server, isConnected, isLoading } = useServer()
@@ -147,7 +156,12 @@ function ServerRouter() {
 
   // Self-hosted server - bypass Clerk, use mock provider
   if (server?.type === 'self-hosted') {
-    return <SelfHostedApp />
+    return (
+      <>
+        <SelfHostedApp />
+        <ServerModal />
+      </>
+    )
   }
 
   // Cloud server - use Clerk auth
@@ -160,6 +174,7 @@ function ServerRouter() {
     <>
       <SignedIn>
         <CloudAuthenticatedApp />
+        <ServerModal />
       </SignedIn>
       <SignedOut>
         <ServerConnect />


### PR DESCRIPTION
## Feature

When clicking 'Switch Server' from dropdown:
- Opens ServerConnect as modal overlay
- Can close with X button or clicking outside
- Stays connected to current server until new one is selected
- No more forced disconnect just to switch

## Changes

| File | Change |
|------|--------|
| `server-context.tsx` | Add `showServerModal`, `openServerModal`, `closeServerModal` |
| `ServerSwitcher.tsx` | Use `openServerModal` instead of `disconnect` |
| `ServerConnect.tsx` | Support `isModal` prop with overlay UI |
| `__root.tsx` | Add `ServerModal` component |

## UX

Before:
1. Click Switch Server → disconnect → lose connection → see ServerConnect fullscreen

After:
1. Click Switch Server → modal overlay appears
2. Can close modal (X or click outside) → stay on current server
3. Or select new server → connect and close modal
