### PR TITLE
fix(web): persist self-hosted credentials on connect

### DIFF
--- a/web/src/lib/server-context.tsx
+++ b/web/src/lib/server-context.tsx
@@ -166,6 +166,17 @@ export function ServerProvider({ children }: { children: ReactNode }) {
     const result = await testConnection(config)
     if (result.ok) {
       setServer(config)
+      // Also save to savedServers list for quick access later
+      setSavedServers(prev => {
+        const existing = prev.findIndex(s => s.url === config.url)
+        if (existing >= 0) {
+          // Update existing entry with new credentials
+          const updated = [...prev]
+          updated[existing] = config
+          return updated
+        }
+        return [...prev, config]
+      })
       return true
     }
     return false


### PR DESCRIPTION
## Problem

Self-hosted server credentials (URL, API key, name) were not persisting across page refreshes.

## Root Cause

`connect()` was setting the current server but not saving to `savedServers` list:

```tsx
// Before: only sets current server
setServer(config)

// After: also saves to list
setServer(config)
setSavedServers(prev => {
  const existing = prev.findIndex(s => s.url === config.url)
  if (existing >= 0) {
    const updated = [...prev]
    updated[existing] = config  // Update existing
    return updated
  }
  return [...prev, config]  // Add new
})
```

## Result

- Credentials persist across refreshes
- Server appears in 'Recent servers' dropdown
- API key saved with server config
