### PR TITLE
fix: harden webhook HTTP client against SSRF

### DIFF
--- a/internal/security/ssrf_test.go
+++ b/internal/security/ssrf_test.go
@@ -103,9 +103,9 @@ func TestValidateIP(t *testing.T) {
 			if ip == nil {
 				t.Fatalf("invalid test IP: %s", tt.ip)
 			}
-			err := validateIP(ip)
+			err := ValidateIP(ip)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("validateIP(%s) error = %v, wantErr %v", tt.ip, err, tt.wantErr)
+				t.Errorf("ValidateIP(%s) error = %v, wantErr %v", tt.ip, err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Add IP validation on every outbound connection via custom `DialContext` in the webhook worker HTTP client, ensuring destination IPs are validated at dial time
- Add `CheckRedirect` handler to limit redirect chain depth
- Export `ValidateIP` from the security package for reuse
- Reject unresolvable hostnames instead of allowing public-looking domains through

## Test plan
- [ ] Verify webhook deliveries to legitimate URLs still work
- [ ] Verify webhooks pointing to private IPs are blocked at delivery time
- [ ] Verify redirect chains to internal IPs are blocked
- [ ] Run existing SSRF unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)