### PR TITLE
fix: validate WebSocket origin against allowed CORS origins

### DIFF
--- a/internal/handler/terminal.go
+++ b/internal/handler/terminal.go
@@ -37,13 +37,15 @@ type terminalMessage struct {
 
 // TerminalHandler handles terminal WebSocket connections.
 type TerminalHandler struct {
-	manager *terminal.Manager
+	manager  *terminal.Manager
+	upgrader ws.Upgrader
 }
 
 // NewTerminalHandler creates a new terminal handler.
-func NewTerminalHandler(manager *terminal.Manager) *TerminalHandler {
+func NewTerminalHandler(manager *terminal.Manager, allowedOrigins []string) *TerminalHandler {
 	return &TerminalHandler{
-		manager: manager,
+		manager:  manager,
+		upgrader: newUpgrader(allowedOrigins),
 	}
 }
 
@@ -83,7 +85,7 @@ func (h *TerminalHandler) HandleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Upgrade to WebSocket
-	conn, err := upgrader.Upgrade(w, r, nil)
+	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		slog.Error("terminal websocket upgrade failed", "error", err)
 		return

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -84,7 +84,7 @@ func (s *Server) routes() http.Handler {
 	})
 
 	// Terminal WebSocket endpoint (requires Clerk JWT, not API key)
-	terminalHandler := handler.NewTerminalHandler(s.terminalManager)
+	terminalHandler := handler.NewTerminalHandler(s.terminalManager, s.cfg.CORSOrigins)
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.UnifiedAuth(queries, s.cfg))
 		r.Use(middleware.RequireClerkAuth(s.cfg))


### PR DESCRIPTION
## Summary
- Replace permissive `CheckOrigin` (always returns `true`) with validation against the configured `CORSOrigins` list
- Non-browser clients without an `Origin` header are still allowed through for CLI/SDK compatibility
- The upgrader is now initialized per-handler with the config's allowed origins

## Test plan
- [ ] Verify WebSocket connections from allowed origins succeed
- [ ] Verify WebSocket connections from disallowed origins are rejected (HTTP 403)
- [ ] Verify CLI/SDK connections without Origin header still work
- [ ] Verify `?token=` auth flow still works for WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)