### PR TITLE
fix: sanitize API error responses and scope stats to tenant

### DIFF
--- a/internal/handler/bootstrap.go
+++ b/internal/handler/bootstrap.go
@@ -121,8 +121,6 @@ func (h *BootstrapHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"bootstrapped": len(keys) > 0,
-		"self_hosted":  h.cfg.IsSelfHosted(),
-		"auth_mode":    string(h.cfg.AuthMode),
 	})
 }
 

--- a/internal/handler/dlq.go
+++ b/internal/handler/dlq.go
@@ -45,7 +45,7 @@ func (h *DLQHandler) List(w http.ResponseWriter, r *http.Request) {
 	entries, err := h.reader.List(r.Context(), authCtx.OrgID, authCtx.ProjectID, topic, limit)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": "failed to list DLQ: " + err.Error(),
+			"error": "failed to list DLQ",
 		})
 		return
 	}
@@ -140,7 +140,7 @@ func (h *DLQHandler) Replay(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.reader.Replay(r.Context(), seq, h.publisher); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": "failed to replay: " + err.Error(),
+			"error": "failed to replay message",
 		})
 		return
 	}
@@ -184,7 +184,7 @@ func (h *DLQHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.reader.Delete(r.Context(), seq); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": "failed to delete: " + err.Error(),
+			"error": "failed to delete message",
 		})
 		return
 	}
@@ -207,7 +207,7 @@ func (h *DLQHandler) ReplayAll(w http.ResponseWriter, r *http.Request) {
 	entries, err := h.reader.List(r.Context(), authCtx.OrgID, authCtx.ProjectID, topic, 1000)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": "failed to list DLQ: " + err.Error(),
+			"error": "failed to list DLQ",
 		})
 		return
 	}
@@ -241,7 +241,7 @@ func (h *DLQHandler) Purge(w http.ResponseWriter, r *http.Request) {
 	entries, err := h.reader.List(r.Context(), authCtx.OrgID, authCtx.ProjectID, topic, 1000)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": "failed to list DLQ: " + err.Error(),
+			"error": "failed to list DLQ",
 		})
 		return
 	}

--- a/internal/handler/emit.go
+++ b/internal/handler/emit.go
@@ -49,7 +49,7 @@ func (h *EmitHandler) Emit(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": "invalid JSON: " + err.Error(),
+			"error": "invalid JSON payload",
 		})
 		return
 	}

--- a/internal/handler/schedules.go
+++ b/internal/handler/schedules.go
@@ -74,7 +74,7 @@ func (h *SchedulesHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	var req CreateScheduleRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON payload"})
 		return
 	}
 
@@ -91,7 +91,7 @@ func (h *SchedulesHandler) Create(w http.ResponseWriter, r *http.Request) {
 	} else if req.In != "" {
 		duration, err := time.ParseDuration(req.In)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid duration: " + err.Error()})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid duration format, use Go duration syntax (e.g. 5m, 1h30m)"})
 			return
 		}
 		scheduledFor = time.Now().Add(duration)

--- a/internal/handler/schemas.go
+++ b/internal/handler/schemas.go
@@ -45,7 +45,7 @@ func (h *SchemaHandler) CreateSchema(w http.ResponseWriter, r *http.Request) {
 
 	s, err := h.registry.CreateSchema(ctx, auth.OrgID, auth.ProjectID, &req)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create schema"})
 		return
 	}
 
@@ -63,7 +63,7 @@ func (h *SchemaHandler) ListSchemas(w http.ResponseWriter, r *http.Request) {
 
 	schemas, err := h.registry.ListSchemas(ctx, auth.ProjectID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list schemas"})
 		return
 	}
 
@@ -127,7 +127,7 @@ func (h *SchemaHandler) UpdateSchema(w http.ResponseWriter, r *http.Request) {
 
 	s, err := h.registry.UpdateSchema(ctx, existing.ID, &req)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update schema"})
 		return
 	}
 
@@ -157,7 +157,7 @@ func (h *SchemaHandler) DeleteSchema(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.registry.DeleteSchema(ctx, existing.ID); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete schema"})
 		return
 	}
 
@@ -207,7 +207,7 @@ func (h *SchemaHandler) CreateVersion(w http.ResponseWriter, r *http.Request) {
 	}
 	v, err := h.registry.CreateVersion(ctx, existing.ID, &req, createdBy)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to create schema version"})
 		return
 	}
 
@@ -238,7 +238,7 @@ func (h *SchemaHandler) ListVersions(w http.ResponseWriter, r *http.Request) {
 
 	versions, err := h.registry.ListVersions(ctx, existing.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list versions"})
 		return
 	}
 
@@ -310,7 +310,7 @@ func (h *SchemaHandler) Validate(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.registry.Validate(ctx, existing.ID, req.Data)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "validation failed"})
 		return
 	}
 
@@ -335,7 +335,7 @@ func (h *SchemaHandler) GetSchemaForTopic(w http.ResponseWriter, r *http.Request
 
 	s, err := h.registry.GetSchemaForTopic(ctx, auth.ProjectID, topic)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get schema for topic"})
 		return
 	}
 

--- a/internal/handler/stats.go
+++ b/internal/handler/stats.go
@@ -31,7 +31,6 @@ type OverviewResponse struct {
 	Events   EventsOverview   `json:"events"`
 	Webhooks WebhooksOverview `json:"webhooks"`
 	DLQ      DLQOverview      `json:"dlq"`
-	APIKeys  APIKeysOverview  `json:"api_keys"`
 }
 
 type EventsOverview struct {
@@ -89,12 +88,6 @@ func (h *StatsHandler) Overview(w http.ResponseWriter, r *http.Request) {
 	// DLQ stats (project-scoped)
 	if dlqCount, err := h.dlqReader.Count(r.Context(), authCtx.OrgID, authCtx.ProjectID); err == nil {
 		resp.DLQ.Pending = dlqCount
-	}
-
-	// API key stats
-	if keyStats, err := h.queries.GetAPIKeyStats(r.Context(), orgIDParam); err == nil {
-		resp.APIKeys.Total = keyStats.Total
-		resp.APIKeys.Active24h = keyStats.Active24h
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/handler/webhook.go
+++ b/internal/handler/webhook.go
@@ -59,7 +59,7 @@ func (h *WebhookHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	// Validate URL to prevent SSRF attacks
 	if err := security.ValidateWebhookURL(req.URL); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid webhook URL: " + err.Error()})
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid webhook URL"})
 		return
 	}
 
@@ -198,7 +198,7 @@ func (h *WebhookHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.URL != "" {
 		// Validate new URL to prevent SSRF attacks
 		if err := security.ValidateWebhookURL(req.URL); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid webhook URL: " + err.Error()})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid webhook URL"})
 			return
 		}
 		url = req.URL

--- a/tests/e2e/api_test.go
+++ b/tests/e2e/api_test.go
@@ -875,15 +875,6 @@ func TestEventsReplayAPI(t *testing.T) {
 		if _, ok := result["messages"]; !ok {
 			t.Error("expected messages field")
 		}
-		if _, ok := result["bytes"]; !ok {
-			t.Error("expected bytes field")
-		}
-		if _, ok := result["first_seq"]; !ok {
-			t.Error("expected first_seq field")
-		}
-		if _, ok := result["last_seq"]; !ok {
-			t.Error("expected last_seq field")
-		}
 	})
 
 	t.Run("events requires authorization", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove internal error details (Go error strings) from all API handler responses to prevent information disclosure
- Replace global NATS stream stats in `GET /events/stats` with project-scoped count from PostgreSQL
- Remove `auth_mode` and `self_hosted` from `GET /bootstrap/status` response
- Remove `api_keys` count from `GET /stats/overview` response

## Test plan
- [ ] Verify error responses return generic messages (e.g. `"invalid JSON payload"` instead of Go error details)
- [ ] Verify `GET /events/stats` returns project-scoped count
- [ ] Verify `GET /bootstrap/status` only returns `bootstrapped` field
- [ ] Verify `GET /stats/overview` does not include `api_keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)