### PR TITLE
fix: remove secrets from retry queue and restrict terminal env

### DIFF
--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -122,14 +122,16 @@ func (m *Manager) CreateSession(userID, orgID, projectID, jwt string, cols, rows
 		Rows:      rows,
 	}
 
-	// Build CLI command
+	// Build CLI command with minimal environment (do not inherit server env)
 	cmd := exec.Command(m.cliBin, "shell")
-	cmd.Env = append(os.Environ(),
-		"NOTIF_JWT="+jwt,
-		"NOTIF_SERVER="+m.server,
-		"NOTIF_PROJECT_ID="+projectID,
+	cmd.Env = []string{
+		"NOTIF_JWT=" + jwt,
+		"NOTIF_SERVER=" + m.server,
+		"NOTIF_PROJECT_ID=" + projectID,
 		"TERM=xterm-256color",
-	)
+		"PATH=/usr/local/bin:/usr/bin:/bin",
+		"HOME=/tmp",
+	}
 
 	// Start with PTY
 	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{

--- a/internal/webhook/worker.go
+++ b/internal/webhook/worker.go
@@ -35,19 +35,19 @@ var retryDelays = []time.Duration{
 	30 * time.Minute,  // 5th retry
 }
 
-// RetryJob represents a webhook delivery retry job
+// RetryJob represents a webhook delivery retry job.
+// Note: Secret and URL are fetched from the database at retry time
+// instead of being stored in the message queue.
 type RetryJob struct {
-	WebhookID   string          `json:"webhook_id"`
-	WebhookURL  string          `json:"webhook_url"`
-	Secret      string          `json:"secret"`
-	EventID     string          `json:"event_id"`
-	OrgID       string          `json:"org_id"`
-	Topic       string          `json:"topic"`
-	Data        json.RawMessage `json:"data"`
-	Timestamp   time.Time       `json:"timestamp"`
-	Attempt     int             `json:"attempt"`
-	LastError   string          `json:"last_error"`
-	DeliveryID  string          `json:"delivery_id"`
+	WebhookID  string          `json:"webhook_id"`
+	EventID    string          `json:"event_id"`
+	OrgID      string          `json:"org_id"`
+	Topic      string          `json:"topic"`
+	Data       json.RawMessage `json:"data"`
+	Timestamp  time.Time       `json:"timestamp"`
+	Attempt    int             `json:"attempt"`
+	LastError  string          `json:"last_error"`
+	DeliveryID string          `json:"delivery_id"`
 }
 
 // Worker handles webhook deliveries.
@@ -205,10 +205,19 @@ func (w *Worker) processRetry(ctx context.Context, msg jetstream.Msg) {
 		return
 	}
 
-	// Build webhook struct for delivery
+	// Fetch webhook from database to get current URL and secret
+	webhookID := parseUUID(job.WebhookID)
+	dbWebhook, err := w.queries.GetWebhook(ctx, webhookID)
+	if err != nil {
+		slog.Warn("webhook: webhook not found for retry, skipping", "webhook_id", job.WebhookID)
+		msg.Ack()
+		return
+	}
+
 	wh := &db.Webhook{
-		Url:    job.WebhookURL,
-		Secret: job.Secret,
+		ID:     dbWebhook.ID,
+		Url:    dbWebhook.Url,
+		Secret: dbWebhook.Secret,
 	}
 
 	event := &domain.Event{
@@ -298,8 +307,6 @@ func (w *Worker) deliver(ctx context.Context, wh *db.Webhook, event *domain.Even
 func (w *Worker) scheduleRetry(ctx context.Context, wh *db.Webhook, event *domain.Event, attempt int, lastError, deliveryID string) {
 	job := &RetryJob{
 		WebhookID:  pgUUIDToString(wh.ID),
-		WebhookURL: wh.Url,
-		Secret:     wh.Secret,
 		EventID:    event.ID,
 		OrgID:      event.OrgID,
 		Topic:      event.Topic,


### PR DESCRIPTION
## Summary
- Remove webhook URL and secret from the NATS retry job payload; instead, fetch current values from the database at retry time. This prevents sensitive data from being stored in the message queue.
- Replace `os.Environ()` inheritance in terminal sessions with an explicit allowlist, preventing server credentials from being accessible in user terminal sessions.

## Test plan
- [ ] Verify webhook retries still work (fetch URL/secret from DB)
- [ ] Verify retries for deleted webhooks are gracefully skipped
- [ ] Verify terminal sessions have limited env vars (`env` command should only show allowed vars)
- [ ] Verify terminal CLI functionality still works with minimal env

🤖 Generated with [Claude Code](https://claude.com/claude-code)