### PR TITLE
fix: reject wildcard characters in topic names

### DIFF
--- a/internal/handler/emit.go
+++ b/internal/handler/emit.go
@@ -166,6 +166,9 @@ func validateTopic(topic string) error {
 	if strings.HasPrefix(topic, ".") || strings.HasSuffix(topic, ".") {
 		return &validationError{"topic cannot start or end with ."}
 	}
+	if strings.ContainsAny(topic, ">*") {
+		return &validationError{"topic cannot contain wildcard characters (> or *)"}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Block `>` and `*` characters in event topic names during validation
- These are NATS wildcard characters and should not be used as literal topic names

## Test plan
- [ ] Verify `POST /emit` with `topic: ">"` returns 400
- [ ] Verify `POST /emit` with `topic: "orders.*"` returns 400
- [ ] Verify normal topics like `orders.placed` still work
- [ ] Verify `POST /schedules` with wildcard topics is also rejected (uses same `validateTopic`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)